### PR TITLE
fix: include updatedInput in permission allow result

### DIFF
--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -209,7 +209,7 @@ export class SDKLLMProvider implements LLMProvider {
                   const result = await pendingPerms.waitFor(opts.toolUseID);
 
                   if (result.behavior === 'allow') {
-                    return { behavior: 'allow' as const };
+                    return { behavior: 'allow' as const, updatedInput: input };
                   }
                   return {
                     behavior: 'deny' as const,


### PR DESCRIPTION
## Problem

When a user manually approves a tool permission request via the IM bridge, the `canUseTool` callback returns:

```ts
{ behavior: 'allow' }
```

However, the Claude Code SDK expects every `allow` result to include the `updatedInput` field. Without it, all subsequent tool calls fail with a `ZodError`:

```
ZodError: [
  {
    "expected": "record",
    "code": "invalid_type",
    "path": ["updatedInput"],
    "message": "Invalid input: expected record, received undefined"
  }
]
```

This makes the entire session unusable after the first manual permission approval.

## Root Cause

In `src/llm-provider.ts`, the `canUseTool` handler returns `{ behavior: 'allow' }` without passing through the original `input` as `updatedInput`.

## Fix

Pass the original `input` through as `updatedInput` in the allow result:

```ts
// Before
return { behavior: 'allow' as const };

// After
return { behavior: 'allow' as const, updatedInput: input };
```

## Testing

- Tested with Feishu (Lark) WebSocket long-connection mode
- Verified that manual permission approval now works correctly
- Subsequent tool calls execute without ZodError