### PR TITLE
feat: add CTI_AUTO_APPROVE for channels without interactive permission UI

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -42,3 +42,11 @@ CTI_TG_BOT_TOKEN=your-telegram-bot-token
 # CTI_FEISHU_APP_SECRET=your-app-secret
 # CTI_FEISHU_DOMAIN=https://open.feishu.cn
 # CTI_FEISHU_ALLOWED_USERS=user_id_1,user_id_2
+
+# ── Permission ──
+# Auto-approve all tool permission requests without user confirmation.
+# Useful for channels that lack interactive permission UI (e.g. Feishu
+# WebSocket long-connection mode, where there is no HTTP webhook to
+# render clickable approve/deny buttons).
+# ⚠️  Only enable this in trusted, access-controlled environments.
+# CTI_AUTO_APPROVE=true

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,8 @@ export interface Config {
   discordAllowedUsers?: string[];
   discordAllowedChannels?: string[];
   discordAllowedGuilds?: string[];
+  // Auto-approve all tool permission requests without user confirmation
+  autoApprove?: boolean;
 }
 
 export const CTI_HOME = process.env.CTI_HOME || path.join(os.homedir(), ".claude-to-im");
@@ -88,6 +90,7 @@ export function loadConfig(): Config {
       env.get("CTI_DISCORD_ALLOWED_CHANNELS")
     ),
     discordAllowedGuilds: splitCsv(env.get("CTI_DISCORD_ALLOWED_GUILDS")),
+    autoApprove: env.get("CTI_AUTO_APPROVE") === "true",
   };
 }
 

--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -167,14 +167,17 @@ function buildPrompt(
 
 export class SDKLLMProvider implements LLMProvider {
   private cliPath: string | undefined;
+  private autoApprove: boolean;
 
-  constructor(private pendingPerms: PendingPermissions, cliPath?: string) {
+  constructor(private pendingPerms: PendingPermissions, cliPath?: string, autoApprove = false) {
     this.cliPath = cliPath;
+    this.autoApprove = autoApprove;
   }
 
   streamChat(params: StreamChatParams): ReadableStream<string> {
     const pendingPerms = this.pendingPerms;
     const cliPath = this.cliPath;
+    const autoApprove = this.autoApprove;
 
     return new ReadableStream({
       start(controller) {
@@ -195,6 +198,12 @@ export class SDKLLMProvider implements LLMProvider {
                   input: Record<string, unknown>,
                   opts: { toolUseID: string; suggestions?: string[] },
                 ): Promise<PermissionResult> => {
+                  // Auto-approve if configured (useful for channels without
+                  // interactive permission UI, e.g. Feishu WebSocket mode)
+                  if (autoApprove) {
+                    return { behavior: 'allow' as const, updatedInput: input };
+                  }
+
                   // Emit permission_request SSE event for the bridge
                   controller.enqueue(
                     sseEvent('permission_request', {

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,7 @@ async function resolveProvider(config: Config, pendingPerms: PendingPermissions)
     const cliPath = resolveClaudeCliPath();
     if (cliPath) {
       console.log(`[claude-to-im] Auto: using Claude CLI at ${cliPath}`);
-      return new SDKLLMProvider(pendingPerms, cliPath);
+      return new SDKLLMProvider(pendingPerms, cliPath, config.autoApprove);
     }
     console.log('[claude-to-im] Auto: Claude CLI not found, falling back to Codex');
     const { CodexProvider } = await import('./codex-provider.js');
@@ -61,7 +61,7 @@ async function resolveProvider(config: Config, pendingPerms: PendingPermissions)
     process.exit(1);
   }
   console.log(`[claude-to-im] Using Claude CLI: ${cliPath}`);
-  return new SDKLLMProvider(pendingPerms, cliPath);
+  return new SDKLLMProvider(pendingPerms, cliPath, config.autoApprove);
 }
 
 interface StatusInfo {


### PR DESCRIPTION
## Motivation

Some IM channels — notably **Feishu/Lark in WebSocket long-connection mode** — have no HTTP webhook endpoint to render interactive approve/deny buttons for tool permission requests. In these setups, every tool call blocks forever waiting for a user response that can never arrive, making the bridge unusable.

## Solution

Add a `CTI_AUTO_APPROVE=true` config option that automatically approves all tool permission requests, enabling unattended operation on channels without interactive permission UI.

### Usage

```env
# In ~/.claude-to-im/config.env
CTI_AUTO_APPROVE=true
```

## Changes

| File | Change |
|------|--------|
| `src/config.ts` | Add `autoApprove` field to `Config`, parsed from `CTI_AUTO_APPROVE` env |
| `src/llm-provider.ts` | Short-circuit `canUseTool` when `autoApprove` is enabled |
| `src/main.ts` | Pass `config.autoApprove` through to `SDKLLMProvider` |
| `config.env.example` | Document the new option with security warning |

## Security Considerations

- The option is **opt-in** and **disabled by default**
- A security warning is included in `config.env.example`
- Users should only enable this in trusted, access-controlled environments
- Access control should be enforced via `CTI_FEISHU_ALLOWED_USERS` or equivalent channel-level restrictions

## Testing

- Tested with Feishu WebSocket long-connection mode
- All tool calls execute without blocking
- Combined with the `updatedInput` fix from #2 to ensure correct SDK behavior

## Note

This PR includes the bug fix from #2 (`updatedInput` missing in allow result) as a dependency, since the auto-approve path also needs to return `updatedInput`.