### PR TITLE
feat: add DingTalk (钉钉) platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude-to-IM Skill
 
-Bridge Claude Code / Codex to IM platforms — chat with AI coding agents from Telegram, Discord, or Feishu/Lark.
+Bridge Claude Code / Codex to IM platforms — chat with AI coding agents from Telegram, Discord, Feishu/Lark, or DingTalk.
 
 [中文文档](README_CN.md)
 
@@ -13,7 +13,7 @@ Bridge Claude Code / Codex to IM platforms — chat with AI coding agents from T
 This skill runs a background daemon that connects your IM bots to Claude Code or Codex sessions. Messages from IM are forwarded to the AI coding agent, and responses (including tool use, permission requests, streaming previews) are sent back to your chat.
 
 ```
-You (Telegram/Discord/Feishu)
+You (Telegram/Discord/Feishu/DingTalk)
   ↕ Bot API
 Background Daemon (Node.js)
   ↕ Claude Agent SDK or Codex SDK (configurable via CTI_RUNTIME)
@@ -22,7 +22,7 @@ Claude Code / Codex → reads/writes your codebase
 
 ## Features
 
-- **Three IM platforms** — Telegram, Discord, Feishu/Lark, enable any combination
+- **Four IM platforms** — Telegram, Discord, Feishu/Lark, DingTalk, enable any combination
 - **Interactive setup** — guided wizard collects tokens with step-by-step instructions
 - **Permission control** — tool calls require explicit approval via inline buttons in chat
 - **Streaming preview** — see Claude's response as it types (Telegram & Discord)
@@ -97,7 +97,7 @@ bash ~/code/Claude-to-IM-skill/scripts/install-codex.sh --link
 
 The wizard will guide you through:
 
-1. **Choose channels** — pick Telegram, Discord, Feishu, or any combination
+1. **Choose channels** — pick Telegram, Discord, Feishu, DingTalk, or any combination
 2. **Enter credentials** — the wizard explains exactly where to get each token, which settings to enable, and what permissions to grant
 3. **Set defaults** — working directory, model, and mode
 4. **Validate** — tokens are verified against platform APIs immediately
@@ -158,6 +158,14 @@ The `setup` wizard provides inline guidance for every step. Here's a summary:
 5. **Events & Callbacks**: select **"Long Connection"** as event dispatch method → add `im.message.receive_v1` event
 6. **Publish**: go to "Version Management & Release" → create version → submit for review → approve in Admin Console
 7. **Important**: The bot will NOT work until the version is approved and published
+
+### DingTalk (钉钉)
+
+1. Go to [DingTalk Open Platform](https://open-dev.dingtalk.com/) → Application Development → Enterprise Internal Development → Create Application
+2. Get **AppKey** (Client ID) and **AppSecret** (Client Secret) from Credentials & Basic Info
+3. Enable **Robot** capability under "Add Capability"
+4. Set message receiving mode to **Stream Mode** (WebSocket long connection — no public server needed)
+5. **Publish**: go to "Version Management & Release" → create version → publish → approve in Admin Console
 
 ## Architecture
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,6 +1,6 @@
 # Claude-to-IM Skill
 
-将 Claude Code / Codex 桥接到 IM 平台 —— 在 Telegram、Discord 或飞书中与 AI 编程代理对话。
+将 Claude Code / Codex 桥接到 IM 平台 —— 在 Telegram、Discord、飞书或钉钉中与 AI 编程代理对话。
 
 [English](README.md)
 
@@ -13,7 +13,7 @@
 本 Skill 运行一个后台守护进程，将你的 IM 机器人连接到 Claude Code 或 Codex 会话。来自 IM 的消息被转发给 AI 编程代理，响应（包括工具调用、权限请求、流式预览）会发回到聊天中。
 
 ```
-你 (Telegram/Discord/飞书)
+你 (Telegram/Discord/飞书/钉钉)
   ↕ Bot API
 后台守护进程 (Node.js)
   ↕ Claude Agent SDK 或 Codex SDK（通过 CTI_RUNTIME 配置）
@@ -22,7 +22,7 @@ Claude Code / Codex → 读写你的代码库
 
 ## 功能特点
 
-- **三大 IM 平台** — Telegram、Discord、飞书，可任意组合启用
+- **四大 IM 平台** — Telegram、Discord、飞书、钉钉，可任意组合启用
 - **交互式配置** — 引导式向导逐步收集 token，附带详细获取说明
 - **权限控制** — 工具调用需要在聊天中通过内联按钮明确批准
 - **流式预览** — 实时查看 Claude 的输出（Telegram 和 Discord 支持）
@@ -97,7 +97,7 @@ bash ~/code/Claude-to-IM-skill/scripts/install-codex.sh --link
 
 向导会引导你完成以下步骤：
 
-1. **选择渠道** — 选择 Telegram、Discord、飞书，或任意组合
+1. **选择渠道** — 选择 Telegram、Discord、飞书、钉钉，或任意组合
 2. **输入凭据** — 向导会详细说明如何获取每个 token、需要开启哪些设置、授予哪些权限
 3. **设置默认值** — 工作目录、模型、模式
 4. **验证** — 立即通过平台 API 验证 token 有效性
@@ -158,6 +158,14 @@ bash ~/code/Claude-to-IM-skill/scripts/install-codex.sh --link
 5. **事件与回调**：选择**长连接**作为事件订阅方式 → 添加 `im.message.receive_v1` 事件
 6. **发布**：进入"版本管理与发布" → 创建版本 → 提交审核 → 在管理后台审核通过
 7. **注意**：版本审核通过并发布后机器人才能使用
+
+### 钉钉
+
+1. 前往[钉钉开放平台](https://open-dev.dingtalk.com/) → 应用开发 → 企业内部开发 → 创建应用
+2. 获取 **AppKey**（Client ID）和 **AppSecret**（Client Secret）
+3. 在"添加应用能力"中启用**机器人**
+4. 消息接收模式选择 **Stream 模式**（WebSocket 长连接，无需公网服务器）
+5. **发布**：进入"版本管理与发布" → 创建版本 → 发布 → 在管理后台审核通过
 
 ## 架构
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: claude-to-im
 description: |
-  This skill bridges Claude Code to IM platforms (Telegram, Discord, Feishu/Lark).
+  This skill bridges Claude Code to IM platforms (Telegram, Discord, Feishu/Lark, DingTalk).
   It should be used when the user wants to start a background daemon that forwards
   IM messages to Claude Code sessions, or manage that daemon's lifecycle.
   Trigger on: "claude-to-im", "start bridge", "stop bridge", "bridge status",
@@ -73,10 +73,11 @@ When AskUserQuestion IS available, collect input **one field at a time**. After 
 
 **Step 1 — Choose channels**
 
-Ask which channels to enable (telegram, discord, feishu). Accept comma-separated input. Briefly describe each:
+Ask which channels to enable (telegram, discord, feishu, dingtalk). Accept comma-separated input. Briefly describe each:
 - **telegram** — Best for personal use. Streaming preview, inline permission buttons.
 - **discord** — Good for team use. Server/channel/user-level access control.
 - **feishu** (Lark) — For Feishu/Lark teams. Event-based messaging.
+- **dingtalk** — For DingTalk teams. Stream mode with WebSocket long connection.
 
 **Step 2 — Collect tokens per channel**
 
@@ -85,6 +86,7 @@ For each enabled channel, read `SKILL_DIR/references/setup-guides.md` and presen
 - **Telegram**: Bot Token → confirm (masked) → Chat ID (see guide for how to get it) → confirm → Allowed User IDs (optional). **Important:** At least one of Chat ID or Allowed User IDs must be set, otherwise the bot will reject all messages.
 - **Discord**: Bot Token → confirm (masked) → Allowed User IDs (optional) → Allowed Channel IDs (optional) → Allowed Guild IDs (optional)
 - **Feishu**: App ID → confirm → App Secret → confirm (masked) → Domain (optional) → Allowed User IDs (optional). Guide through all 4 steps (A: batch permissions, B: enable bot, C: events & callbacks with long connection, D: publish version).
+- **DingTalk**: Client ID (AppKey) → confirm → Client Secret (AppSecret) → confirm (masked) → Robot Code (optional, defaults to Client ID) → Allowed User IDs (optional) → Allowed Group IDs (optional). Guide through all 3 steps (A: create app & enable bot, B: configure Stream mode, C: publish).
 
 **Step 3 — General settings**
 

--- a/config.env.example
+++ b/config.env.example
@@ -7,7 +7,7 @@
 #   auto   — tries Claude first, falls back to Codex if CLI not found
 CTI_RUNTIME=claude
 
-# Enabled channels (comma-separated: telegram,discord,feishu)
+# Enabled channels (comma-separated: telegram,discord,feishu,dingtalk)
 CTI_ENABLED_CHANNELS=telegram
 
 # Default working directory for Claude Code sessions
@@ -42,6 +42,13 @@ CTI_TG_CHAT_ID=your-chat-id
 # CTI_FEISHU_APP_SECRET=your-app-secret
 # CTI_FEISHU_DOMAIN=https://open.feishu.cn
 # CTI_FEISHU_ALLOWED_USERS=user_id_1,user_id_2
+
+# ── DingTalk ──
+# CTI_DINGTALK_CLIENT_ID=your-app-key
+# CTI_DINGTALK_CLIENT_SECRET=your-app-secret
+# CTI_DINGTALK_ROBOT_CODE=your-robot-code
+# CTI_DINGTALK_ALLOWED_USERS=staff_id_1,staff_id_2
+# CTI_DINGTALK_ALLOWED_GROUPS=conversation_id_1
 
 # ── Permission ──
 # Auto-approve all tool permission requests without user confirmation.

--- a/references/setup-guides.md
+++ b/references/setup-guides.md
@@ -176,3 +176,55 @@ Leave empty to use the default Feishu domain.
 Feishu user IDs (open_id format like `ou_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`).
 You can find them in the Feishu Admin Console under user profiles.
 Leave empty to allow all users who can message the bot.
+
+---
+
+## DingTalk (钉钉)
+
+### Client ID (AppKey) and Client Secret (AppSecret)
+
+**How to create a DingTalk app and get credentials:**
+1. Go to DingTalk Open Platform: https://open-dev.dingtalk.com/
+2. Click **"Application Development"** → **"Enterprise Internal Development"** → **"Create Application"**
+3. Fill in the app name and description → click **"Create"**
+4. On the app's **"Credentials & Basic Info"** page, find:
+   - **AppKey** (also called Client ID, like `dingxxxxxxxxxx`)
+   - **AppSecret** (also called Client Secret, click to reveal)
+
+### Step A — Enable the bot capability
+
+1. In the app page, go to **"Add Capability"** → enable **"Robot"** (机器人)
+2. Set the robot name, avatar and description
+3. Under robot settings, configure the **message receiving mode** to **"Stream Mode"** (Stream 模式)
+
+### Step B — Configure Stream Mode
+
+1. In the robot settings, make sure **"Stream Mode"** is selected (not HTTP mode)
+2. Stream mode uses WebSocket long connection — no public server URL needed
+3. The robot will automatically connect when the bridge starts
+
+### Step C — Publish the app
+
+1. Go to **"Version Management & Release"** → click **"Create Version"**
+2. Fill in version number and update description → click **"Save"**
+3. Click **"Publish"**
+4. For enterprise internal apps, the admin can approve it in the **DingTalk Admin Console** → **App Management**
+5. **Important:** The bot will NOT respond to messages until the app is published and approved
+
+### Robot Code (optional)
+
+The Robot Code is used for sending proactive messages via OpenAPI. It defaults to the same value as Client ID (AppKey).
+You can find it on the robot configuration page in the DingTalk Open Platform.
+Leave empty to use Client ID as robot code.
+
+### Allowed User IDs (optional)
+
+DingTalk user IDs are **staffId** format (e.g. `manager1234`).
+You can find them in the DingTalk Admin Console under employee profiles, or via the DingTalk contact API.
+Enter comma-separated IDs to restrict access. Leave empty to allow all users.
+
+### Allowed Group IDs (optional)
+
+DingTalk group IDs are **conversationId** format (e.g. `cidXXXXXXXXXX`).
+You can find the conversationId in the webhook callback data when the bot receives a group message.
+Enter comma-separated IDs to restrict the bot to specific groups. Leave empty to allow all groups.

--- a/references/usage.md
+++ b/references/usage.md
@@ -12,7 +12,7 @@ Interactive wizard that configures the bridge.
 
 The wizard will prompt you for:
 
-1. **Channels to enable** -- Enter comma-separated values: `telegram`, `discord`, `feishu`
+1. **Channels to enable** -- Enter comma-separated values: `telegram`, `discord`, `feishu`, `dingtalk`
 2. **Platform credentials** -- Bot tokens, app IDs, and secrets for each enabled channel
 3. **Allowed users** (optional) -- Restrict which users can interact with the bot
 4. **Working directory** -- Default project directory for Claude Code sessions

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -196,6 +196,25 @@ if [ -f "$CONFIG_FILE" ]; then
       check "Discord bot token configured" 1
     fi
   fi
+
+  # --- DingTalk ---
+  if echo "$CTI_CHANNELS" | grep -q dingtalk; then
+    DT_CLIENT_ID=$(get_config CTI_DINGTALK_CLIENT_ID)
+    DT_CLIENT_SECRET=$(get_config CTI_DINGTALK_CLIENT_SECRET)
+    if [ -n "$DT_CLIENT_ID" ] && [ -n "$DT_CLIENT_SECRET" ]; then
+      # Validate by requesting an access token
+      DT_RESULT=$(curl -s --max-time 5 -X POST "https://api.dingtalk.com/v1.0/oauth2/accessToken" \
+        -H "Content-Type: application/json" \
+        -d "{\"appKey\":\"${DT_CLIENT_ID}\",\"appSecret\":\"${DT_CLIENT_SECRET}\"}" 2>/dev/null || echo '{"accessToken":""}')
+      if echo "$DT_RESULT" | grep -q '"accessToken"[[:space:]]*:[[:space:]]*"[^"]'; then
+        check "DingTalk app credentials are valid" 0
+      else
+        check "DingTalk app credentials are valid (accessToken request failed)" 1
+      fi
+    else
+      check "DingTalk app credentials configured" 1
+    fi
+  fi
 fi
 
 # --- Log directory writable ---

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -40,10 +40,11 @@ describe('configToSettings', () => {
   });
 
   it('sets channel enabled flags based on enabledChannels', () => {
-    const m = configToSettings({ ...base, enabledChannels: ['telegram', 'discord'] });
+    const m = configToSettings({ ...base, enabledChannels: ['telegram', 'discord', 'dingtalk'] });
     assert.equal(m.get('bridge_telegram_enabled'), 'true');
     assert.equal(m.get('bridge_discord_enabled'), 'true');
     assert.equal(m.get('bridge_feishu_enabled'), 'false');
+    assert.equal(m.get('bridge_dingtalk_enabled'), 'true');
   });
 
   it('maps telegram config', () => {
@@ -89,6 +90,35 @@ describe('configToSettings', () => {
     assert.equal(m.get('bridge_feishu_allowed_users'), 'fu1');
   });
 
+  it('maps dingtalk config', () => {
+    const m = configToSettings({
+      ...base,
+      enabledChannels: ['dingtalk'],
+      dingtalkClientId: 'dt-app-key',
+      dingtalkClientSecret: 'dt-app-secret',
+      dingtalkRobotCode: 'dt-robot',
+      dingtalkAllowedUsers: ['staff1', 'staff2'],
+      dingtalkAllowedGroups: ['cid123'],
+    });
+    assert.equal(m.get('bridge_dingtalk_enabled'), 'true');
+    assert.equal(m.get('bridge_dingtalk_client_id'), 'dt-app-key');
+    assert.equal(m.get('bridge_dingtalk_client_secret'), 'dt-app-secret');
+    assert.equal(m.get('bridge_dingtalk_robot_code'), 'dt-robot');
+    assert.equal(m.get('bridge_dingtalk_require_mention'), 'true');
+    assert.equal(m.get('bridge_dingtalk_allowed_users'), 'staff1,staff2');
+    assert.equal(m.get('bridge_dingtalk_allowed_groups'), 'cid123');
+  });
+
+  it('uses client_id as robot_code when robot_code not set', () => {
+    const m = configToSettings({
+      ...base,
+      enabledChannels: ['dingtalk'],
+      dingtalkClientId: 'dt-app-key',
+      dingtalkClientSecret: 'dt-app-secret',
+    });
+    assert.equal(m.get('bridge_dingtalk_robot_code'), 'dt-app-key');
+  });
+
   it('maps workdir and mode, omits model when not set', () => {
     const m = configToSettings(base);
     assert.equal(m.get('bridge_default_work_dir'), '/tmp/test');
@@ -113,6 +143,7 @@ describe('configToSettings', () => {
     assert.equal(m.has('telegram_bot_token'), false);
     assert.equal(m.has('bridge_discord_bot_token'), false);
     assert.equal(m.has('bridge_feishu_app_id'), false);
+    assert.equal(m.has('bridge_dingtalk_client_id'), false);
   });
 });
 
@@ -144,5 +175,5 @@ describe('loadConfig/saveConfig round-trip', () => {
     assert.equal(m.get('bridge_telegram_enabled'), 'false');
     assert.equal(m.get('bridge_discord_enabled'), 'false');
     assert.equal(m.get('bridge_feishu_enabled'), 'false');
-  });
+    assert.equal(m.get('bridge_dingtalk_enabled'), 'false');
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,12 @@ export interface Config {
   discordAllowedUsers?: string[];
   discordAllowedChannels?: string[];
   discordAllowedGuilds?: string[];
+  // DingTalk
+  dingtalkClientId?: string;
+  dingtalkClientSecret?: string;
+  dingtalkRobotCode?: string;
+  dingtalkAllowedUsers?: string[];
+  dingtalkAllowedGroups?: string[];
   // Auto-approve all tool permission requests without user confirmation
   autoApprove?: boolean;
 }
@@ -89,6 +95,11 @@ export function loadConfig(): Config {
       env.get("CTI_DISCORD_ALLOWED_CHANNELS")
     ),
     discordAllowedGuilds: splitCsv(env.get("CTI_DISCORD_ALLOWED_GUILDS")),
+    dingtalkClientId: env.get("CTI_DINGTALK_CLIENT_ID") || undefined,
+    dingtalkClientSecret: env.get("CTI_DINGTALK_CLIENT_SECRET") || undefined,
+    dingtalkRobotCode: env.get("CTI_DINGTALK_ROBOT_CODE") || undefined,
+    dingtalkAllowedUsers: splitCsv(env.get("CTI_DINGTALK_ALLOWED_USERS")),
+    dingtalkAllowedGroups: splitCsv(env.get("CTI_DINGTALK_ALLOWED_GROUPS")),
     autoApprove: env.get("CTI_AUTO_APPROVE") === "true",
   };
 }
@@ -133,6 +144,17 @@ export function saveConfig(config: Config): void {
   out += formatEnvLine(
     "CTI_DISCORD_ALLOWED_GUILDS",
     config.discordAllowedGuilds?.join(",")
+  );
+  out += formatEnvLine("CTI_DINGTALK_CLIENT_ID", config.dingtalkClientId);
+  out += formatEnvLine("CTI_DINGTALK_CLIENT_SECRET", config.dingtalkClientSecret);
+  out += formatEnvLine("CTI_DINGTALK_ROBOT_CODE", config.dingtalkRobotCode);
+  out += formatEnvLine(
+    "CTI_DINGTALK_ALLOWED_USERS",
+    config.dingtalkAllowedUsers?.join(",")
+  );
+  out += formatEnvLine(
+    "CTI_DINGTALK_ALLOWED_GROUPS",
+    config.dingtalkAllowedGroups?.join(",")
   );
 
   fs.mkdirSync(CTI_HOME, { recursive: true });
@@ -198,6 +220,29 @@ export function configToSettings(config: Config): Map<string, string> {
   if (config.feishuDomain) m.set("bridge_feishu_domain", config.feishuDomain);
   if (config.feishuAllowedUsers)
     m.set("bridge_feishu_allowed_users", config.feishuAllowedUsers.join(","));
+
+  // ── DingTalk ──
+  // Upstream keys: bridge_dingtalk_client_id, bridge_dingtalk_client_secret,
+  //   bridge_dingtalk_robot_code, bridge_dingtalk_enabled,
+  //   bridge_dingtalk_allowed_users, bridge_dingtalk_allowed_groups,
+  //   bridge_dingtalk_require_mention
+  m.set(
+    "bridge_dingtalk_enabled",
+    config.enabledChannels.includes("dingtalk") ? "true" : "false"
+  );
+  if (config.dingtalkClientId)
+    m.set("bridge_dingtalk_client_id", config.dingtalkClientId);
+  if (config.dingtalkClientSecret)
+    m.set("bridge_dingtalk_client_secret", config.dingtalkClientSecret);
+  if (config.dingtalkRobotCode)
+    m.set("bridge_dingtalk_robot_code", config.dingtalkRobotCode);
+  else if (config.dingtalkClientId)
+    m.set("bridge_dingtalk_robot_code", config.dingtalkClientId);
+  m.set("bridge_dingtalk_require_mention", "true");
+  if (config.dingtalkAllowedUsers)
+    m.set("bridge_dingtalk_allowed_users", config.dingtalkAllowedUsers.join(","));
+  if (config.dingtalkAllowedGroups)
+    m.set("bridge_dingtalk_allowed_groups", config.dingtalkAllowedGroups.join(","));
 
   // ── Defaults ──
   // Upstream keys: bridge_default_work_dir, bridge_default_model, default_model


### PR DESCRIPTION
## Summary

- Add DingTalk as the fourth supported IM platform (alongside Telegram, Discord, Feishu)
- DingTalk uses **Stream mode** (WebSocket long connection) via `dingtalk-stream-sdk-nodejs` — no public server needed
- Full integration with the setup wizard, config management, doctor diagnostics, and documentation

## Changes (9 files, +186 lines)

| File | Description |
|---|---|
| `SKILL.md` | Add dingtalk to channel selection and credential collection flow |
| `src/config.ts` | Add 5 DingTalk fields to Config interface + loadConfig/saveConfig/configToSettings |
| `config.env.example` | Add `CTI_DINGTALK_*` configuration entries |
| `references/setup-guides.md` | Complete DingTalk setup guide (create app → Stream mode → publish) |
| `scripts/doctor.sh` | DingTalk credential validation via `accessToken` API |
| `references/usage.md` | Add dingtalk to channel list |
| `src/__tests__/config.test.ts` | 3 new test cases (config mapping, enabled flag, robot_code default) |
| `README.md` | Update to four platforms, add DingTalk quick start section |
| `README_CN.md` | Same updates in Chinese |

## Context

This PR adds the skill-side support for the DingTalk adapter that was implemented in the upstream `claude-to-im` library ([Claude-to-IM](https://github.com/anthropics/claude-to-im)). The adapter implementation includes:
- Stream mode message receiving via `DWClient`
- sessionWebhook + OpenAPI fallback for message sending
- DingTalk-compatible Markdown rendering with 20K char chunking
- User/group whitelist authorization
- Image download support

## Test plan

- [ ] Run `npm test` — verify 3 new config tests pass
- [ ] Run `/claude-to-im setup` — verify DingTalk appears in channel selection
- [ ] Configure DingTalk credentials → verify config.env has correct `CTI_DINGTALK_*` entries
- [ ] Run `/claude-to-im doctor` — verify DingTalk credential validation works
- [ ] Start bridge with DingTalk enabled → send message to bot → verify response

🤖 Generated with [Claude Code](https://claude.com/claude-code)