### PR TITLE
fix: expand shell vars in config and add spawn fallback for native binary

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,14 @@ function parseEnvFile(content: string): Map<string, string> {
   return entries;
 }
 
+function expandShellVars(value: string): string {
+  return value
+    .replace(/\$\{HOME\}/g, os.homedir())
+    .replace(/\$HOME/g, os.homedir())
+    .replace(/\$\{CWD\}/g, process.cwd())
+    .replace(/\$CWD/g, process.cwd());
+}
+
 function splitCsv(value: string | undefined): string[] | undefined {
   if (!value) return undefined;
   return value
@@ -73,7 +81,7 @@ export function loadConfig(): Config {
   return {
     runtime,
     enabledChannels: splitCsv(env.get("CTI_ENABLED_CHANNELS")) ?? [],
-    defaultWorkDir: env.get("CTI_DEFAULT_WORKDIR") || process.cwd(),
+    defaultWorkDir: expandShellVars(env.get("CTI_DEFAULT_WORKDIR") || process.cwd()),
     defaultModel: env.get("CTI_DEFAULT_MODEL") || undefined,
     defaultMode: env.get("CTI_DEFAULT_MODE") || "code",
     tgBotToken: env.get("CTI_TG_BOT_TOKEN") || undefined,

--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -6,7 +6,8 @@
  */
 
 import fs from 'node:fs';
-import { execSync } from 'node:child_process';
+import path from 'node:path';
+import { execSync, execFileSync } from 'node:child_process';
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import type { SDKMessage, PermissionResult } from '@anthropic-ai/claude-agent-sdk';
 import type { LLMProvider, StreamChatParams, FileAttachment } from 'claude-to-im/src/lib/bridge/host.js';
@@ -88,11 +89,43 @@ function isExecutable(p: string): boolean {
 }
 
 /**
+ * Return the path to the SDK's bundled cli.js, which can always be run via `node`.
+ * Used as a fallback when the native binary cannot be spawned.
+ */
+function sdkCliFallback(): string | undefined {
+  try {
+    // The SDK is an external module — resolve its location then find cli.js next to it.
+    const sdkMain = require.resolve('@anthropic-ai/claude-agent-sdk');
+    const candidate = path.join(path.dirname(sdkMain), 'cli.js');
+    if (isExecutable(candidate)) return candidate;
+  } catch {
+    // SDK not resolvable (unusual)
+  }
+  return undefined;
+}
+
+/**
+ * Verify a native binary can actually be spawned in the current process context.
+ * File-existence checks (X_OK) are insufficient — in some environments (e.g. macOS
+ * launchd agents) an executable that exists on disk still fails to spawn with ENOENT.
+ */
+function canSpawn(binaryPath: string): boolean {
+  try {
+    execFileSync(binaryPath, ['--version'], { timeout: 3000, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Resolve the path to the `claude` CLI executable.
  * Priority: CTI_CLAUDE_CODE_EXECUTABLE env → which/where command → common install paths.
+ * For native binaries, validates that spawn actually works and falls back to the
+ * SDK's bundled cli.js if not (e.g. launchd sandbox restrictions).
  */
 export function resolveClaudeCliPath(): string | undefined {
-  // 1. Explicit env var
+  // 1. Explicit env var — trust it without spawn-testing (user opted in explicitly)
   const fromEnv = process.env.CTI_CLAUDE_CODE_EXECUTABLE;
   if (fromEnv && isExecutable(fromEnv)) return fromEnv;
 
@@ -101,7 +134,11 @@ export function resolveClaudeCliPath(): string | undefined {
   const cmd = isWindows ? 'where claude' : 'which claude';
   try {
     const resolved = execSync(cmd, { encoding: 'utf-8', timeout: 3000 }).trim().split('\n')[0];
-    if (resolved && isExecutable(resolved)) return resolved;
+    if (resolved && isExecutable(resolved)) {
+      if (canSpawn(resolved)) return resolved;
+      console.warn(`[llm-provider] '${resolved}' exists but cannot be spawned — falling back to SDK cli.js`);
+      return sdkCliFallback();
+    }
   } catch {
     // not found in PATH
   }
@@ -119,7 +156,11 @@ export function resolveClaudeCliPath(): string | undefined {
         `${process.env.HOME}/.local/bin/claude`,
       ];
   for (const p of candidates) {
-    if (p && isExecutable(p)) return p;
+    if (p && isExecutable(p)) {
+      if (canSpawn(p)) return p;
+      console.warn(`[llm-provider] '${p}' exists but cannot be spawned — falling back to SDK cli.js`);
+      return sdkCliFallback();
+    }
   }
 
   return undefined;


### PR DESCRIPTION
## 问题

在实际使用中发现两个 bug，会导致 bridge 启动后无法处理消息。

### Bug 1：`$CWD` 被当作字面量存入配置

`CTI_DEFAULT_WORKDIR=$CWD` 写入 `config.env` 后，`loadConfig()` 读取的是字符串 `$CWD` 而不是实际路径。当 SDK 以 `cwd: "$CWD"` 启动子进程时，Node.js 找不到该目录，抛出 ENOENT——但错误信息却是 SDK 的误导性报错 "Claude Code native binary not found"，让人完全无法定位根因。

### Bug 2：原生 binary 在某些环境下无法 spawn

在 macOS launchd agent 环境下，`fs.accessSync(path, X_OK)` 通过，但实际 `spawn()` 仍然失败（ENOENT）。原有代码没有降级机制，直接把 SDK 的内部报错透传给用户。

## 修复

**`src/config.ts`**
- 新增 `expandShellVars()`，在读取配置时将 `$CWD`、`$HOME`（含 `${...}` 形式）展开为实际路径

**`src/llm-provider.ts`**
- 新增 `canSpawn()`：用 `execFileSync --version` 实际验证 binary 是否可以在当前进程上下文中启动
- 新增 `sdkCliFallback()`：通过 `require.resolve` 定位 SDK 内置的 `cli.js`，作为原生 binary 不可用时的降级方案
- `resolveClaudeCliPath()` 在找到原生 binary 后先做 spawn 健康检查，失败则自动切换到 `node cli.js` 并打印清晰的警告日志