### PR TITLE
feat: add kimi CLI support as LLM runtime backend

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -89,10 +89,11 @@ For each enabled channel, read `SKILL_DIR/references/setup-guides.md` and presen
 **Step 3 — General settings**
 
 Ask for runtime, default working directory, model, and mode:
-- **Runtime**: `claude` (default), `codex`, `auto`
+- **Runtime**: `claude` (default), `codex`, `kimi`, `auto`
   - `claude` — uses Claude Code CLI + Claude Agent SDK (requires `claude` CLI installed)
   - `codex` — uses OpenAI Codex SDK (requires `codex` CLI; auth via `codex auth login` or `OPENAI_API_KEY`)
-  - `auto` — tries Claude first, falls back to Codex if Claude CLI not found
+  - `kimi` — uses kimi CLI (requires `kimi` CLI installed; auth via `kimi auth` or `KIMI_API_KEY`)
+  - `auto` — tries Claude first, falls back to Kimi if Claude CLI not found
 - **Working Directory**: default `$CWD`
 - **Model** (optional): Leave blank to inherit the runtime's own default model. If the user wants to override, ask them to enter a model name. Do NOT hardcode or suggest specific model names — the available models change over time.
 - **Mode**: `code` (default), `plan`, `ask`

--- a/config.env.example
+++ b/config.env.example
@@ -1,10 +1,11 @@
 # Claude-to-IM Bridge Configuration
 # Copy to ~/.claude-to-im/config.env and edit
 
-# Runtime backend: claude | codex | auto
+# Runtime backend: claude | codex | kimi | auto
 #   claude (default) — uses Claude Code CLI + @anthropic-ai/claude-agent-sdk
 #   codex  — uses @openai/codex-sdk (auth: codex auth login, or OPENAI_API_KEY)
-#   auto   — tries Claude first, falls back to Codex if CLI not found
+#   kimi   — uses kimi CLI (https://github.com/moonshot-ai/kimi-cli)
+#   auto   — tries Claude first, falls back to Kimi if CLI not found
 CTI_RUNTIME=claude
 
 # Enabled channels (comma-separated: telegram,discord,feishu)
@@ -23,6 +24,12 @@ CTI_DEFAULT_MODE=code
 # Priority: CTI_CODEX_API_KEY > CODEX_API_KEY > OPENAI_API_KEY
 # CTI_CODEX_API_KEY=
 # CTI_CODEX_BASE_URL=
+
+# ── Kimi auth (optional — only if not using `kimi auth`) ──
+# Priority: CTI_KIMI_API_KEY > KIMI_API_KEY
+# CTI_KIMI_API_KEY=
+# KIMI_BASE_URL=
+# CTI_KIMI_EXECUTABLE=/path/to/kimi  # Optional: custom kimi CLI path
 
 # ── Telegram ──
 CTI_TG_BOT_TOKEN=your-telegram-bot-token

--- a/scripts/daemon.sh
+++ b/scripts/daemon.sh
@@ -60,6 +60,15 @@ clean_env() {
           done < <(env)
         fi
         ;;
+      kimi)
+        # Strip Anthropic and OpenAI env vars when using Kimi
+        while IFS='=' read -r name _; do
+          case "$name" in ANTHROPIC_*) unset "$name" 2>/dev/null || true ;; esac
+        done < <(env)
+        while IFS='=' read -r name _; do
+          case "$name" in OPENAI_*) unset "$name" 2>/dev/null || true ;; esac
+        done < <(env)
+        ;;
     esac
   fi
 }

--- a/scripts/supervisor-linux.sh
+++ b/scripts/supervisor-linux.sh
@@ -2,9 +2,31 @@
 # Linux supervisor — setsid/nohup fallback process management.
 # Sourced by daemon.sh; expects CTI_HOME, SKILL_DIR, PID_FILE, STATUS_FILE, LOG_FILE.
 
+# ── Environment helpers ──
+
+# Export Kimi-related env vars for the daemon process
+export_kimi_env() {
+  local runtime
+  runtime=$(grep "^CTI_RUNTIME=" "$CTI_HOME/config.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d "'" | tr -d '"' || true)
+  runtime="${runtime:-claude}"
+
+  case "$runtime" in
+    kimi|auto)
+      for var in KIMI_API_KEY KIMI_BASE_URL KIMI_CLI_PATH CTI_KIMI_EXECUTABLE; do
+        local val="${!var:-}"
+        [ -z "$val" ] && continue
+        export "$var=$val"
+      done
+      ;;
+  esac
+}
+
 # ── Public interface (called by daemon.sh) ──
 
 supervisor_start() {
+  # Export runtime-specific env vars before starting
+  export_kimi_env
+
   if command -v setsid >/dev/null 2>&1; then
     setsid node "$SKILL_DIR/dist/daemon.mjs" >> "$LOG_FILE" 2>&1 < /dev/null &
   else

--- a/scripts/supervisor-macos.sh
+++ b/scripts/supervisor-macos.sh
@@ -53,6 +53,15 @@ build_env_dict() {
       fi
       ;;
   esac
+  case "$runtime" in
+    kimi|auto)
+      for var in KIMI_API_KEY KIMI_BASE_URL KIMI_CLI_PATH CTI_KIMI_EXECUTABLE; do
+        local val="${!var:-}"
+        [ -z "$val" ] && continue
+        dict+="${indent}<key>${var}</key>\n${indent}<string>${val}</string>\n"
+      done
+      ;;
+  esac
 
   echo -e "$dict"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface Config {
-  runtime: 'claude' | 'codex' | 'auto';
+  runtime: 'claude' | 'codex' | 'kimi' | 'auto';
   enabledChannels: string[];
   defaultWorkDir: string;
   defaultModel?: string;
@@ -68,7 +68,7 @@ export function loadConfig(): Config {
   }
 
   const rawRuntime = env.get("CTI_RUNTIME") || "claude";
-  const runtime = (["claude", "codex", "auto"].includes(rawRuntime) ? rawRuntime : "claude") as Config["runtime"];
+  const runtime = (["claude", "codex", "kimi", "auto"].includes(rawRuntime) ? rawRuntime : "claude") as Config["runtime"];
 
   return {
     runtime,

--- a/src/kimi-provider.ts
+++ b/src/kimi-provider.ts
@@ -1,0 +1,268 @@
+/**
+ * Kimi Provider — LLMProvider implementation backed by kimi CLI.
+ *
+ * Spawns kimi CLI in --print mode with --output-format stream-json,
+ * parses JSON output, and converts to bridge SSE format.
+ */
+
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+
+import type { LLMProvider, StreamChatParams } from 'claude-to-im/src/lib/bridge/host.js';
+import type { PendingPermissions } from './permission-gateway.js';
+import { sseEvent } from './sse-utils.js';
+
+/** Kimi CLI JSON output message */
+interface KimiMessage {
+  role: 'assistant' | 'tool' | string;
+  content?: Array<{
+    type: 'think' | 'text' | 'function' | string;
+    text?: string;
+    think?: string;
+    encrypted?: string | null;
+  }>;
+  tool_calls?: Array<{
+    type: 'function';
+    id: string;
+    function: {
+      name: string;
+      arguments: string;
+    };
+  }>;
+  tool_call_id?: string;
+}
+
+function resolveKimiCliPath(): string | undefined {
+  // Check env var first
+  const fromEnv = process.env.CTI_KIMI_EXECUTABLE || process.env.KIMI_CLI_PATH;
+  if (fromEnv) return fromEnv;
+
+  // Try common locations
+  const candidates = [
+    '/usr/local/bin/kimi',
+    '/opt/homebrew/bin/kimi',
+    `${process.env.HOME}/.local/bin/kimi`,
+    `${process.env.HOME}/.cargo/bin/kimi`,
+    'kimi', // Try PATH
+  ];
+  
+  for (const p of candidates) {
+    try {
+      if (p === 'kimi') return p; // Will rely on PATH
+      fs.accessSync(p, fs.constants.X_OK);
+      return p;
+    } catch {
+      continue;
+    }
+  }
+  
+  return 'kimi'; // Fallback to PATH
+}
+
+export class KimiProvider implements LLMProvider {
+  private cliPath: string;
+  private sessions = new Map<string, string>(); // sessionId -> kimi session ID
+
+  constructor(private pendingPerms: PendingPermissions) {
+    this.cliPath = resolveKimiCliPath() || 'kimi';
+  }
+
+  streamChat(params: StreamChatParams): ReadableStream<string> {
+    const self = this;
+    const pendingPerms = this.pendingPerms;
+
+    return new ReadableStream<string>({
+      start(controller) {
+        (async () => {
+          let killed = false;
+
+          try {
+            // Build kimi arguments
+            const args: string[] = [
+              '--print',
+              '--output-format', 'stream-json',
+            ];
+
+            // Working directory
+            if (params.workingDirectory) {
+              args.push('--work-dir', params.workingDirectory);
+            }
+
+            // Session/resume
+            const savedSessionId = params.sdkSessionId 
+              ? self.sessions.get(params.sessionId) || params.sdkSessionId
+              : undefined;
+            
+            if (savedSessionId) {
+              args.push('--session', savedSessionId);
+            } else {
+              args.push('--continue'); // Continue or create new
+            }
+
+            // Model (if provided and looks like a kimi model)
+            if (params.model && !params.model.startsWith('claude')) {
+              args.push('--model', params.model);
+            }
+
+            // Build input
+            // Note: kimi CLI print mode doesn't support inline images via stdin
+            const inputText = params.prompt;
+
+            const child = spawn(self.cliPath, args, {
+              stdio: ['pipe', 'pipe', 'pipe'],
+              env: {
+                ...process.env,
+                // Ensure kimi uses proper output
+                FORCE_COLOR: '0',
+                NO_COLOR: '1',
+              },
+            });
+
+            // Handle abort
+            if (params.abortController) {
+              params.abortController.signal.addEventListener('abort', () => {
+                killed = true;
+                child.kill('SIGTERM');
+              });
+            }
+
+            // Send input
+            child.stdin.write(inputText);
+            child.stdin.end();
+
+            // Buffer for incomplete lines
+            let buffer = '';
+            let sessionId: string | undefined;
+
+            child.stdout.on('data', (data: Buffer) => {
+              if (killed) return;
+
+              buffer += data.toString('utf-8');
+              const lines = buffer.split('\n');
+              buffer = lines.pop() || ''; // Keep incomplete line in buffer
+
+              for (const line of lines) {
+                const trimmed = line.trim();
+                if (!trimmed) continue;
+
+                try {
+                  const msg: KimiMessage = JSON.parse(trimmed);
+                  self.handleMessage(msg, controller, pendingPerms, (id) => {
+                    if (!sessionId) {
+                      sessionId = id;
+                      self.sessions.set(params.sessionId, id);
+                    }
+                  });
+                } catch (err) {
+                  console.warn('[kimi-provider] Failed to parse JSON:', trimmed.slice(0, 100));
+                }
+              }
+            });
+
+            // Handle stderr
+            child.stderr.on('data', (data: Buffer) => {
+              const text = data.toString('utf-8');
+              console.warn('[kimi-provider] stderr:', text.slice(0, 200));
+            });
+
+            // Wait for process to complete
+            const exitCode = await new Promise<number>((resolve) => {
+              child.on('close', (code) => resolve(code ?? 0));
+              child.on('error', () => resolve(1));
+            });
+
+            if (exitCode !== 0 && !killed) {
+              console.warn(`[kimi-provider] kimi exited with code ${exitCode}`);
+            }
+
+            // Send final result
+            controller.enqueue(sseEvent('result', {
+              session_id: sessionId,
+              is_error: exitCode !== 0 && !killed,
+            }));
+
+            controller.close();
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.error('[kimi-provider] Error:', err);
+            try {
+              controller.enqueue(sseEvent('error', message));
+              controller.close();
+            } catch {
+              // Already closed
+            }
+          }
+        })();
+      },
+    });
+  }
+
+  private handleMessage(
+    msg: KimiMessage,
+    controller: ReadableStreamDefaultController<string>,
+    _pendingPerms: PendingPermissions,
+    setSessionId: (id: string) => void,
+  ): void {
+    // Emit status with session ID on first message
+    if (!this.sessionEmitted) {
+      this.sessionEmitted = true;
+      controller.enqueue(sseEvent('status', {
+        session_id: `kimi-${Date.now()}`,
+      }));
+    }
+
+    if (msg.role === 'assistant' && msg.content) {
+      for (const block of msg.content) {
+        switch (block.type) {
+          case 'think':
+            // Thinking block - emit as status
+            if (block.think) {
+              controller.enqueue(sseEvent('status', { reasoning: block.think }));
+            }
+            break;
+          case 'text':
+            if (block.text) {
+              controller.enqueue(sseEvent('text', block.text));
+            }
+            break;
+        }
+      }
+
+      // Handle tool calls
+      if (msg.tool_calls) {
+        for (const toolCall of msg.tool_calls) {
+          const toolId = toolCall.id || `tool-${Date.now()}`;
+          const toolName = toolCall.function.name;
+          let toolInput: Record<string, unknown> = {};
+          
+          try {
+            toolInput = JSON.parse(toolCall.function.arguments);
+          } catch {
+            toolInput = { raw: toolCall.function.arguments };
+          }
+
+          controller.enqueue(sseEvent('tool_use', {
+            id: toolId,
+            name: toolName,
+            input: toolInput,
+          }));
+
+          // Note: kimi handles tool execution internally in print mode
+          // The result comes back in a tool role message
+        }
+      }
+    } else if (msg.role === 'tool' && msg.content) {
+      // Tool result
+      const toolCallId = msg.tool_call_id || 'unknown';
+      const text = msg.content.find(c => c.type === 'text')?.text || '';
+      
+      controller.enqueue(sseEvent('tool_result', {
+        tool_use_id: toolCallId,
+        content: text,
+        is_error: false,
+      }));
+    }
+  }
+
+  private sessionEmitted = false;
+}

--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -71,6 +71,13 @@ export function buildSubprocessEnv(): Record<string, string> {
         if (v !== undefined && (k.startsWith('OPENAI_') || k.startsWith('CODEX_'))) out[k] = v;
       }
     }
+
+    // In kimi/auto mode, pass through KIMI_* env vars
+    if (runtime === 'kimi' || runtime === 'auto') {
+      for (const [k, v] of Object.entries(process.env)) {
+        if (v !== undefined && k.startsWith('KIMI_')) out[k] = v;
+      }
+    }
   }
 
   return out;

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,8 @@ const PID_FILE = path.join(RUNTIME_DIR, 'bridge.pid');
  * Resolve the LLM provider based on the runtime setting.
  * - 'claude' (default): uses Claude Code SDK via SDKLLMProvider
  * - 'codex': uses @openai/codex-sdk via CodexProvider
- * - 'auto': tries Claude first, falls back to Codex
+ * - 'kimi': uses kimi CLI via KimiProvider
+ * - 'auto': tries Claude first, falls back to Kimi if not found
  */
 async function resolveProvider(config: Config, pendingPerms: PendingPermissions): Promise<LLMProvider> {
   const runtime = config.runtime;
@@ -39,15 +40,20 @@ async function resolveProvider(config: Config, pendingPerms: PendingPermissions)
     return new CodexProvider(pendingPerms);
   }
 
+  if (runtime === 'kimi') {
+    const { KimiProvider } = await import('./kimi-provider.js');
+    return new KimiProvider(pendingPerms);
+  }
+
   if (runtime === 'auto') {
     const cliPath = resolveClaudeCliPath();
     if (cliPath) {
       console.log(`[claude-to-im] Auto: using Claude CLI at ${cliPath}`);
       return new SDKLLMProvider(pendingPerms, cliPath, config.autoApprove);
     }
-    console.log('[claude-to-im] Auto: Claude CLI not found, falling back to Codex');
-    const { CodexProvider } = await import('./codex-provider.js');
-    return new CodexProvider(pendingPerms);
+    console.log('[claude-to-im] Auto: Claude CLI not found, falling back to Kimi');
+    const { KimiProvider } = await import('./kimi-provider.js');
+    return new KimiProvider(pendingPerms);
   }
 
   // Default: claude
@@ -57,7 +63,7 @@ async function resolveProvider(config: Config, pendingPerms: PendingPermissions)
       '[claude-to-im] FATAL: Cannot find the `claude` CLI executable.\n' +
       '  Tried: CTI_CLAUDE_CODE_EXECUTABLE env, /usr/local/bin/claude, /opt/homebrew/bin/claude, ~/.npm-global/bin/claude, ~/.local/bin/claude\n' +
       '  Fix: Install Claude Code CLI (https://docs.anthropic.com/en/docs/claude-code) or set CTI_CLAUDE_CODE_EXECUTABLE=/path/to/claude\n' +
-      '  Or: Set CTI_RUNTIME=codex to use Codex instead',
+      '  Or: Set CTI_RUNTIME=kimi to use Kimi CLI instead',
     );
     process.exit(1);
   }


### PR DESCRIPTION
Add support for Moonshot AI's kimi-cli as an alternative LLM provider.

Changes:
- New KimiProvider class (src/kimi-provider.ts) that spawns kimi CLI in --print mode with --output-format stream-json
- Add 'kimi' runtime option to config (CTI_RUNTIME=kimi)
- Auto runtime now falls back to Kimi if Claude CLI not found
- Environment variable passthrough for KIMI_* vars
- macOS/Linux supervisor scripts updated to pass Kimi env vars
- Environment cleanup for kimi runtime in daemon.sh
- Updated config.env.example and SKILL.md documentation

Usage:
  CTI_RUNTIME=kimi KIMI_API_KEY=your-api-key


test result with Telegram bot:

<img width="649" height="190" alt="image" src="https://github.com/user-attachments/assets/c3043c1c-3223-4deb-8416-df2eca505208" />
