### PR TITLE
fix: add CTI_NET_FAMILY=4 option to force IPv4 for fetch()

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -50,3 +50,13 @@ CTI_TG_CHAT_ID=your-chat-id
 # render clickable approve/deny buttons).
 # ⚠️  Only enable this in trusted, access-controlled environments.
 # CTI_AUTO_APPROVE=true
+
+# ── Network ──
+# Force IPv4 for all outgoing fetch() calls.
+# Node.js 22's built-in fetch (undici) prefers IPv6 when available.
+# In some network environments (e.g. certain VPNs, proxies, or ISPs
+# with broken IPv6), this causes silent timeouts when connecting to
+# api.telegram.org and other external APIs.
+# Note: --dns-result-order=ipv4first does NOT affect undici's fetch.
+# Set to 4 to force IPv4. Leave unset for default behavior.
+# CTI_NET_FAMILY=4

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,24 @@
  * Assembles all DI implementations and starts the bridge.
  */
 
+// ── IPv4-only network fix ──────────────────────────────────────────
+// Node.js 22's built-in fetch (undici) prefers IPv6 when available.
+// In some network environments IPv6 routes to api.telegram.org (and
+// other external APIs) are unreachable, causing silent timeouts.
+// The `--dns-result-order=ipv4first` CLI flag does NOT affect undici.
+// Setting CTI_NET_FAMILY=4 forces all fetch() calls to use IPv4.
+// This block MUST run before any import that may trigger fetch().
+if (process.env.CTI_NET_FAMILY === '4') {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { Agent, setGlobalDispatcher } = require('undici') as typeof import('undici');
+    setGlobalDispatcher(new Agent({ connect: { family: 4 } as never }));
+    console.log('[claude-to-im] Network: forced IPv4 (CTI_NET_FAMILY=4)');
+  } catch {
+    console.warn('[claude-to-im] Warning: could not set IPv4-only dispatcher');
+  }
+}
+
 import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';


### PR DESCRIPTION
## Problem

Node.js 22's built-in `fetch` (powered by undici) prefers IPv6 when available. In some network environments (VPNs, proxies, certain ISPs with broken IPv6 routing), this causes **silent timeouts** when connecting to `api.telegram.org` and other external APIs.

**Symptom:** Telegram adapter reports `Polling error: fetch failed` and `getMe failed ... timeout` continuously. The bot never receives messages. Meanwhile, `curl` works fine because it defaults to IPv4.

**Key insight:** The `--dns-result-order=ipv4first` Node.js flag does **NOT** affect undici's `fetch()` — it only affects the legacy `dns` module.

## Solution

Added a new config option `CTI_NET_FAMILY=4` that forces all `fetch()` calls to use IPv4 by setting a global undici dispatcher with `family: 4`.

### Changes

**`src/main.ts`** — At the top of the entry point (before any other imports that might trigger fetch), check `CTI_NET_FAMILY` and configure undici:

```typescript
if (process.env.CTI_NET_FAMILY === '4') {
  const { Agent, setGlobalDispatcher } = require('undici');
  setGlobalDispatcher(new Agent({ connect: { family: 4 } }));
}
```

**`config.env.example`** — Added documentation for the new option:
```bash
# ── Network ──
# Force IPv4 for all outgoing fetch() calls.
# CTI_NET_FAMILY=4
```

### Design decisions

1. **Opt-in, not default** — Only activates when explicitly set. Users with working IPv6 are not affected.
2. **Runs before imports** — Placed at the very top of `main.ts` to ensure it takes effect before adapter modules start making requests.
3. **No new dependencies** — Uses Node.js 22's built-in `undici` module.
4. **Works with launchd** — `supervisor-macos.sh` already forwards all `CTI_*` env vars to launchd, so this option works automatically.

### Testing

- Build passes: `npm run build` ✅
- Manually verified on macOS with broken IPv6 routing — Telegram adapter connects successfully with `CTI_NET_FAMILY=4`

Relates to #12