### PR TITLE
fix: align Codex sandbox behavior with code mode and auto-approve

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -58,6 +58,9 @@ CTI_TG_CHAT_ID=your-chat-id
 # Auto-approve all tool permission requests without user confirmation.
 # Useful for channels that lack interactive permission UI (e.g. Feishu
 # WebSocket long-connection mode, where there is no HTTP webhook to
-# render clickable approve/deny buttons).
+# render clickable approve/deny buttons). In Codex runtime, this maps
+# to a non-interactive approval policy; it does not widen sandbox access
+# by itself. Codex only gets workspace write access in code mode
+# (`acceptEdits` / `CTI_DEFAULT_MODE=code`).
 # ⚠️  Only enable this in trusted, access-controlled environments.
 # CTI_AUTO_APPROVE=true

--- a/src/__tests__/codex-provider.test.ts
+++ b/src/__tests__/codex-provider.test.ts
@@ -331,6 +331,144 @@ describe('CodexProvider', () => {
     }
   });
 
+  it('uses workspace-write sandbox in acceptEdits mode', async () => {
+    const { CodexProvider } = await import('../codex-provider.js');
+    const { PendingPermissions } = await import('../permission-gateway.js');
+    const provider = new CodexProvider(new PendingPermissions());
+
+    let capturedStartOptions: Record<string, unknown> | undefined;
+    const mockThread = {
+      runStreamed: () => ({
+        events: (async function* () {
+          yield { type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 1, cached_input_tokens: 0 } };
+        })(),
+      }),
+    };
+
+    (provider as any).sdk = { Codex: class { constructor() {} } };
+    (provider as any).codex = {
+      startThread: (opts: Record<string, unknown>) => {
+        capturedStartOptions = opts;
+        return mockThread;
+      },
+    };
+
+    const stream = provider.streamChat({
+      prompt: 'edit files',
+      sessionId: 'workspace-write-session',
+      permissionMode: 'acceptEdits',
+      workingDirectory: '/tmp/project',
+    });
+
+    await collectStream(stream);
+
+    assert.equal(capturedStartOptions?.approvalPolicy, 'on-failure');
+    assert.equal(capturedStartOptions?.sandboxMode, 'workspace-write');
+    assert.equal(capturedStartOptions?.workingDirectory, '/tmp/project');
+  });
+
+  it('keeps sandbox unset outside acceptEdits mode', async () => {
+    const { CodexProvider } = await import('../codex-provider.js');
+    const { PendingPermissions } = await import('../permission-gateway.js');
+    const provider = new CodexProvider(new PendingPermissions());
+
+    let capturedStartOptions: Record<string, unknown> | undefined;
+    const mockThread = {
+      runStreamed: () => ({
+        events: (async function* () {
+          yield { type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 1, cached_input_tokens: 0 } };
+        })(),
+      }),
+    };
+
+    (provider as any).sdk = { Codex: class { constructor() {} } };
+    (provider as any).codex = {
+      startThread: (opts: Record<string, unknown>) => {
+        capturedStartOptions = opts;
+        return mockThread;
+      },
+    };
+
+    const stream = provider.streamChat({
+      prompt: 'plan only',
+      sessionId: 'sandbox-default-session',
+      permissionMode: 'plan',
+    });
+
+    await collectStream(stream);
+
+    assert.equal(capturedStartOptions?.approvalPolicy, 'on-request');
+    assert.ok(!Object.prototype.hasOwnProperty.call(capturedStartOptions!, 'sandboxMode'));
+  });
+
+  it('uses never approval when autoApprove is enabled', async () => {
+    const { CodexProvider } = await import('../codex-provider.js');
+    const { PendingPermissions } = await import('../permission-gateway.js');
+    const provider = new CodexProvider(new PendingPermissions(), true);
+
+    let capturedStartOptions: Record<string, unknown> | undefined;
+    const mockThread = {
+      runStreamed: () => ({
+        events: (async function* () {
+          yield { type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 1, cached_input_tokens: 0 } };
+        })(),
+      }),
+    };
+
+    (provider as any).sdk = { Codex: class { constructor() {} } };
+    (provider as any).codex = {
+      startThread: (opts: Record<string, unknown>) => {
+        capturedStartOptions = opts;
+        return mockThread;
+      },
+    };
+
+    const stream = provider.streamChat({
+      prompt: 'run unattended',
+      sessionId: 'auto-approve-session',
+      permissionMode: 'plan',
+    });
+
+    await collectStream(stream);
+
+    assert.equal(capturedStartOptions?.approvalPolicy, 'never');
+    assert.ok(!Object.prototype.hasOwnProperty.call(capturedStartOptions!, 'sandboxMode'));
+  });
+
+  it('keeps workspace-write in acceptEdits even when autoApprove is enabled', async () => {
+    const { CodexProvider } = await import('../codex-provider.js');
+    const { PendingPermissions } = await import('../permission-gateway.js');
+    const provider = new CodexProvider(new PendingPermissions(), true);
+
+    let capturedStartOptions: Record<string, unknown> | undefined;
+    const mockThread = {
+      runStreamed: () => ({
+        events: (async function* () {
+          yield { type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 1, cached_input_tokens: 0 } };
+        })(),
+      }),
+    };
+
+    (provider as any).sdk = { Codex: class { constructor() {} } };
+    (provider as any).codex = {
+      startThread: (opts: Record<string, unknown>) => {
+        capturedStartOptions = opts;
+        return mockThread;
+      },
+    };
+
+    const stream = provider.streamChat({
+      prompt: 'edit unattended',
+      sessionId: 'auto-approve-edit-session',
+      permissionMode: 'acceptEdits',
+    });
+
+    await collectStream(stream);
+
+    assert.equal(capturedStartOptions?.approvalPolicy, 'never');
+    assert.equal(capturedStartOptions?.sandboxMode, 'workspace-write');
+  });
+
   it('retries with fresh thread when resume fails before any events', async () => {
     const { CodexProvider } = await import('../codex-provider.js');
     const { PendingPermissions } = await import('../permission-gateway.js');

--- a/src/codex-provider.ts
+++ b/src/codex-provider.ts
@@ -37,17 +37,24 @@ type ThreadInstance = any;
 
 /**
  * Map bridge permission modes to Codex approval policies.
+ * - CTI auto-approve → 'never' (unattended; no interactive approval)
  * - 'acceptEdits' (code mode) → 'on-failure' (auto-approve most things)
  * - 'plan' → 'on-request' (ask before executing)
  * - 'default' (ask mode) → 'on-request'
  */
-function toApprovalPolicy(permissionMode?: string): string {
+function toApprovalPolicy(permissionMode?: string, autoApprove = false): string {
+  if (autoApprove) return 'never';
+
   switch (permissionMode) {
     case 'acceptEdits': return 'on-failure';
     case 'plan': return 'on-request';
     case 'default': return 'on-request';
     default: return 'on-request';
   }
+}
+
+function toSandboxMode(permissionMode?: string): string | undefined {
+  return permissionMode === 'acceptEdits' ? 'workspace-write' : undefined;
 }
 
 /** Whether to forward bridge model to Codex CLI. Default: false (use Codex current/default model). */
@@ -75,7 +82,7 @@ export class CodexProvider implements LLMProvider {
   /** Maps session IDs to Codex thread IDs for resume. */
   private threadIds = new Map<string, string>();
 
-  constructor(private pendingPerms: PendingPermissions) {}
+  constructor(private pendingPerms: PendingPermissions, private autoApprove = false) {}
 
   /**
    * Lazily load the Codex SDK. Throws a clear error if not installed.
@@ -133,12 +140,14 @@ export class CodexProvider implements LLMProvider {
               savedThreadId = undefined;
             }
 
-            const approvalPolicy = toApprovalPolicy(params.permissionMode);
+            const approvalPolicy = toApprovalPolicy(params.permissionMode, self.autoApprove);
+            const sandboxMode = toSandboxMode(params.permissionMode);
             const passModel = shouldPassModelToCodex();
 
             const threadOptions: Record<string, unknown> = {
               ...(passModel && params.model ? { model: params.model } : {}),
               ...(params.workingDirectory ? { workingDirectory: params.workingDirectory } : {}),
+              ...(sandboxMode ? { sandboxMode } : {}),
               approvalPolicy,
             };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ async function resolveProvider(config: Config, pendingPerms: PendingPermissions)
 
   if (runtime === 'codex') {
     const { CodexProvider } = await import('./codex-provider.js');
-    return new CodexProvider(pendingPerms);
+    return new CodexProvider(pendingPerms, config.autoApprove);
   }
 
   if (runtime === 'auto') {
@@ -47,7 +47,7 @@ async function resolveProvider(config: Config, pendingPerms: PendingPermissions)
     }
     console.log('[claude-to-im] Auto: Claude CLI not found, falling back to Codex');
     const { CodexProvider } = await import('./codex-provider.js');
-    return new CodexProvider(pendingPerms);
+    return new CodexProvider(pendingPerms, config.autoApprove);
   }
 
   // Default: claude


### PR DESCRIPTION
## What

Fix Codex bridge permission behavior for unattended sessions.

## Changes

- pass `config.autoApprove` into `CodexProvider`
- use non-interactive approval when `CTI_AUTO_APPROVE=true`
- default to `workspace-write` sandbox in `acceptEdits` / code mode
- keep sandbox unchanged in non-code modes
- add regression tests for approval + sandbox combinations
- document Codex sandbox behavior in `config.env.example`

## Why

`CTI_AUTO_APPROVE` was only applied on the Claude path.

In Codex runtime, approval policy and sandbox mode were not aligned with bridge mode, which could cause working-directory write failures during real bridge usage.

This PR makes the behavior consistent:

- `CTI_AUTO_APPROVE` controls approval flow
- `acceptEdits` controls workspace write access

## Verification

- `npm run typecheck`
- `npm test`

```
ℹ tests 83
ℹ suites 10
ℹ pass 83
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
```

## Notes

Existing bindings may still keep their previously stored mode. To get `workspace-write`, the session needs to run in `code` mode.
