### PR TITLE
fix: handle circular JSON in logger

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -59,13 +59,21 @@ function rotateIfNeeded(): void {
   logStream = openLogStream();
 }
 
+function safeStringify(a: unknown): string {
+  try {
+    return JSON.stringify(a);
+  } catch {
+    return String(a);
+  }
+}
+
 export function setupLogger(): void {
   fs.mkdirSync(LOG_DIR, { recursive: true });
   logStream = openLogStream();
 
   const write = (level: string, args: unknown[]) => {
     const timestamp = new Date().toISOString();
-    const message = args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+    const message = args.map((a) => (typeof a === 'string' ? a : safeStringify(a))).join(' ');
     const formatted = `[${timestamp}] [${level}] ${message}`;
     const masked = maskSecrets(formatted);
 


### PR DESCRIPTION
## Summary

When logging objects with circular references (e.g., TLS certificates), JSON.stringify throws TypeError. This fix adds a safeStringify function that catches the error and falls back to String(a).

## Changes

- Added safeStringify() function that wraps JSON.stringify with try/catch
- Updated logger's write function to use safeStringify() instead of direct JSON.stringify()

## Test plan

- [x] Bridge starts without crashing on circular JSON error
- [x] Logs still work correctly for normal objects