### PR TITLE
fix: PowerShell 5.1 compatibility for Windows supervisor script

### DIFF
--- a/scripts/supervisor-windows.ps1
+++ b/scripts/supervisor-windows.ps1
@@ -33,8 +33,8 @@ $SkillDir   = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
 $RuntimeDir = Join-Path $CtiHome 'runtime'
 $PidFile    = Join-Path $RuntimeDir 'bridge.pid'
 $StatusFile = Join-Path $RuntimeDir 'status.json'
-$LogFile    = Join-Path $CtiHome 'logs' 'bridge.log'
-$DaemonMjs  = Join-Path $SkillDir 'dist' 'daemon.mjs'
+$LogFile    = Join-Path (Join-Path $CtiHome 'logs') 'bridge.log'
+$DaemonMjs  = Join-Path (Join-Path $SkillDir 'dist') 'daemon.mjs'
 
 $ServiceName = 'ClaudeToIMBridge'
 
@@ -72,9 +72,9 @@ function Read-Pid {
 }
 
 function Test-PidAlive {
-    param([string]$Pid)
-    if (-not $Pid) { return $false }
-    try { $null = Get-Process -Id ([int]$Pid) -ErrorAction Stop; return $true }
+    param([string]$ProcessId)
+    if (-not $ProcessId) { return $false }
+    try { $null = Get-Process -Id ([int]$ProcessId) -ErrorAction Stop; return $true }
     catch { return $false }
 }
 
@@ -221,12 +221,13 @@ function Start-Fallback {
     # Remove CLAUDECODE
     [System.Environment]::SetEnvironmentVariable('CLAUDECODE', $null)
 
+    $stderrLog = Join-Path (Join-Path $CtiHome 'logs') 'bridge-stderr.log'
     $proc = Start-Process -FilePath $nodePath `
         -ArgumentList $DaemonMjs `
         -WorkingDirectory $SkillDir `
         -WindowStyle Hidden `
         -RedirectStandardOutput $LogFile `
-        -RedirectStandardError $LogFile `
+        -RedirectStandardError $stderrLog `
         -PassThru
 
     # Write initial PID (main.ts will overwrite with real PID)
@@ -267,7 +268,7 @@ switch ($Command) {
             }
         } else {
             Write-Host "Starting bridge (background process)..."
-            $pid = Start-Fallback
+            $bridgePid = Start-Fallback
             Start-Sleep -Seconds 3
 
             $newPid = Read-Pid
@@ -294,10 +295,10 @@ switch ($Command) {
             Write-Host "Bridge stopped"
             if (Test-Path $PidFile) { Remove-Item $PidFile -Force }
         } else {
-            $pid = Read-Pid
-            if (-not $pid) { Write-Host "No bridge running"; exit 0 }
-            if (Test-PidAlive $pid) {
-                Stop-Process -Id ([int]$pid) -Force
+            $bridgePid = Read-Pid
+            if (-not $bridgePid) { Write-Host "No bridge running"; exit 0 }
+            if (Test-PidAlive $bridgePid) {
+                Stop-Process -Id ([int]$bridgePid) -Force
                 Write-Host "Bridge stopped"
             } else {
                 Write-Host "Bridge was not running (stale PID file)"
@@ -307,7 +308,7 @@ switch ($Command) {
     }
 
     'status' {
-        $pid = Read-Pid
+        $bridgePid = Read-Pid
 
         # Check Windows Service
         $svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
@@ -315,8 +316,8 @@ switch ($Command) {
             Write-Host "Windows Service '$ServiceName': $($svc.Status)"
         }
 
-        if ($pid -and (Test-PidAlive $pid)) {
-            Write-Host "Bridge process is running (PID: $pid)"
+        if ($bridgePid -and (Test-PidAlive $bridgePid)) {
+            Write-Host "Bridge process is running (PID: $bridgePid)"
             if (Test-StatusRunning) {
                 Write-Host "Bridge status: running"
             } else {


### PR DESCRIPTION
## Summary

- Fix `Join-Path` 3-parameter syntax unsupported in PowerShell 5.1 (default on Windows 10/11)
- Fix `$PID` read-only automatic variable conflict by renaming to `$bridgePid`
- Fix `Start-Process` failing when `RedirectStandardOutput` and `RedirectStandardError` point to the same file

## Problem

The Windows supervisor script (`scripts/supervisor-windows.ps1`) fails on systems with PowerShell 5.1 (the default version on Windows 10/11). Three separate issues prevent the daemon from starting:

### 1. `Join-Path` with 3 arguments
PowerShell 5.1 only supports 2 arguments for `Join-Path`. The `-AdditionalChildPath` parameter was added in PowerShell 6.0+.
```powershell
# Fails in PS 5.1:
$LogFile = Join-Path $CtiHome 'logs' 'bridge.log'
# Fix:
$LogFile = Join-Path (Join-Path $CtiHome 'logs') 'bridge.log'
```

### 2. `$PID` is a read-only variable
`$PID` is an automatic variable in PowerShell (current process ID). Assigning to `$pid` (case-insensitive) throws `VariableNotWritable`.
```powershell
# Fails in PS 5.1:
$pid = Start-Fallback
# Fix:
$bridgePid = Start-Fallback
```

### 3. `Start-Process` stdout/stderr same file
PowerShell 5.1 throws `InvalidOperationException` when both `-RedirectStandardOutput` and `-RedirectStandardError` point to the same file path.
```powershell
# Fix: split stderr to a separate log file
$stderrLog = Join-Path (Join-Path $CtiHome 'logs') 'bridge-stderr.log'
```

## Test plan
- [x] Tested on Windows 11 Pro, PowerShell 5.1.26100.7705
- [ ] Verify backward compatibility on PowerShell 7+
- [ ] Test `start`, `stop`, `status` subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)