### PR TITLE
fix(codex): add opt-in skipGitRepoCheck for non-git workdirs

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -37,6 +37,8 @@ CTI_DEFAULT_MODE=code
 # Priority: CTI_CODEX_API_KEY > CODEX_API_KEY > OPENAI_API_KEY
 # CTI_CODEX_API_KEY=
 # CTI_CODEX_BASE_URL=
+# Skip Codex trusted-directory checks for non-git working directories
+# CTI_CODEX_SKIP_GIT_REPO_CHECK=true
 
 # ── Telegram ──
 CTI_TG_BOT_TOKEN=your-telegram-bot-token

--- a/src/__tests__/codex-provider.test.ts
+++ b/src/__tests__/codex-provider.test.ts
@@ -331,6 +331,47 @@ describe('CodexProvider', () => {
     }
   });
 
+  it('passes skipGitRepoCheck only when CTI_CODEX_SKIP_GIT_REPO_CHECK=true', async () => {
+    const old = process.env.CTI_CODEX_SKIP_GIT_REPO_CHECK;
+    process.env.CTI_CODEX_SKIP_GIT_REPO_CHECK = 'true';
+    try {
+      const { CodexProvider } = await import('../codex-provider.js');
+      const { PendingPermissions } = await import('../permission-gateway.js');
+      const provider = new CodexProvider(new PendingPermissions());
+
+      let capturedStartOptions: Record<string, unknown> | undefined;
+      const mockThread = {
+        runStreamed: () => ({
+          events: (async function* () {
+            yield { type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 1, cached_input_tokens: 0 } };
+          })(),
+        }),
+      };
+      (provider as any).sdk = { Codex: class { constructor() {} } };
+      (provider as any).codex = {
+        startThread: (opts: Record<string, unknown>) => {
+          capturedStartOptions = opts;
+          return mockThread;
+        },
+      };
+
+      const stream = provider.streamChat({
+        prompt: 'hello',
+        sessionId: 'skip-git-check-session',
+        workingDirectory: '/tmp/not-a-repo',
+      });
+      await collectStream(stream);
+
+      assert.equal(capturedStartOptions?.skipGitRepoCheck, true);
+    } finally {
+      if (old === undefined) {
+        delete process.env.CTI_CODEX_SKIP_GIT_REPO_CHECK;
+      } else {
+        process.env.CTI_CODEX_SKIP_GIT_REPO_CHECK = old;
+      }
+    }
+  });
+
   it('retries with fresh thread when resume fails before any events', async () => {
     const { CodexProvider } = await import('../codex-provider.js');
     const { PendingPermissions } = await import('../permission-gateway.js');

--- a/src/codex-provider.ts
+++ b/src/codex-provider.ts
@@ -55,6 +55,11 @@ function shouldPassModelToCodex(): boolean {
   return process.env.CTI_CODEX_PASS_MODEL === 'true';
 }
 
+/** Whether to bypass Codex's git repository trust gate for the working directory. */
+function shouldSkipGitRepoCheck(): boolean {
+  return process.env.CTI_CODEX_SKIP_GIT_REPO_CHECK === 'true';
+}
+
 function looksLikeClaudeModel(model?: string): boolean {
   return !!model && /^claude[-_]/i.test(model);
 }
@@ -135,10 +140,12 @@ export class CodexProvider implements LLMProvider {
 
             const approvalPolicy = toApprovalPolicy(params.permissionMode);
             const passModel = shouldPassModelToCodex();
+            const skipGitRepoCheck = shouldSkipGitRepoCheck();
 
             const threadOptions: Record<string, unknown> = {
               ...(passModel && params.model ? { model: params.model } : {}),
               ...(params.workingDirectory ? { workingDirectory: params.workingDirectory } : {}),
+              ...(skipGitRepoCheck ? { skipGitRepoCheck: true } : {}),
               approvalPolicy,
             };
 


### PR DESCRIPTION
## Summary
- add an opt-in `CTI_CODEX_SKIP_GIT_REPO_CHECK=true` switch for Codex threads
- pass `skipGitRepoCheck: true` to the SDK only when that env var is enabled
- document the new setting in `config.env.example` and cover it with a unit test

## Why
Bridge deployments often use a non-repo working directory such as `/home/user` or `/Users/name`, which causes Codex runs to fail with:

`Not inside a trusted directory and --skip-git-repo-check was not specified.`

An earlier PR (#37) bundled this capability with unrelated features. This keeps the Codex fix isolated and reviewable.

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`
