### PR TITLE
fix(windows): harden WinSW service management

### DIFF
--- a/scripts/check-windows-service.ps1
+++ b/scripts/check-windows-service.ps1
@@ -1,0 +1,99 @@
+param(
+    [int]$LogLines = 20
+)
+
+$ErrorActionPreference = 'Stop'
+
+$serviceName = 'ClaudeToIMBridge'
+$ctiHome = if ($env:CTI_HOME) { $env:CTI_HOME } else { Join-Path $env:USERPROFILE '.claude-to-im' }
+$statusFile = Join-Path (Join-Path $ctiHome 'runtime') 'status.json'
+$logFile = Join-Path (Join-Path $ctiHome 'logs') 'bridge.log'
+$wrapperLogFile = Join-Path (Join-Path $ctiHome 'logs') 'ClaudeToIMBridge.wrapper.log'
+$outLogFile = Join-Path (Join-Path $ctiHome 'logs') 'ClaudeToIMBridge.out.log'
+$errLogFile = Join-Path (Join-Path $ctiHome 'logs') 'ClaudeToIMBridge.err.log'
+
+function Get-LatestServicePid {
+    param([string]$WrapperLogPath)
+
+    if (-not (Test-Path $WrapperLogPath)) {
+        return $null
+    }
+
+    $startedLine = Get-Content $WrapperLogPath | Select-String -Pattern 'Started process ' | Select-Object -Last 1
+    if (-not $startedLine) {
+        return $null
+    }
+
+    $match = [regex]::Match($startedLine.Line, 'Started process (\d+)')
+    if (-not $match.Success) {
+        return $null
+    }
+
+    return [int]$match.Groups[1].Value
+}
+
+Write-Host "== Windows Service =="
+try {
+    Get-Service -Name $serviceName | Select-Object Name, Status, StartType | Format-Table -AutoSize
+} catch {
+    Write-Host "Service '$serviceName' not found."
+}
+
+Write-Host ""
+Write-Host "== Service Config =="
+sc.exe qc $serviceName
+
+Write-Host ""
+Write-Host "== Active Process (from WinSW) =="
+$servicePid = Get-LatestServicePid -WrapperLogPath $wrapperLogFile
+if ($servicePid) {
+    try {
+        Get-Process -Id $servicePid | Select-Object Id, ProcessName, StartTime, CPU | Format-Table -AutoSize
+    } catch {
+        Write-Host "Last started service process was PID $servicePid, but it is not running now."
+    }
+} else {
+    Write-Host "Could not determine service child PID from $wrapperLogFile"
+}
+
+Write-Host ""
+Write-Host "== Bridge Status File =="
+if (Test-Path $statusFile) {
+    Get-Content $statusFile
+    Write-Host ""
+    Write-Host "(Note: status.json can be stale after manual stop/start. Compare it with the service state and wrapper log above.)"
+} else {
+    Write-Host "No status file found at $statusFile"
+}
+
+Write-Host ""
+Write-Host "== WinSW Wrapper Logs =="
+if (Test-Path $wrapperLogFile) {
+    Get-Content $wrapperLogFile -Tail $LogLines
+} else {
+    Write-Host "No wrapper log found at $wrapperLogFile"
+}
+
+Write-Host ""
+Write-Host "== Service Stdout =="
+if (Test-Path $outLogFile) {
+    Get-Content $outLogFile -Tail $LogLines
+} else {
+    Write-Host "No stdout log found at $outLogFile"
+}
+
+Write-Host ""
+Write-Host "== Service Stderr =="
+if (Test-Path $errLogFile) {
+    Get-Content $errLogFile -Tail $LogLines
+} else {
+    Write-Host "No stderr log found at $errLogFile"
+}
+
+Write-Host ""
+Write-Host "== Recent Bridge Logs =="
+if (Test-Path $logFile) {
+    Get-Content $logFile -Tail $LogLines
+} else {
+    Write-Host "No bridge log found at $logFile"
+}

--- a/scripts/daemon.ps1
+++ b/scripts/daemon.ps1
@@ -13,4 +13,4 @@ param(
 )
 
 $supervisorScript = Join-Path (Split-Path -Parent $PSCommandPath) 'supervisor-windows.ps1'
-& $supervisorScript $Command $LogLines
+& $supervisorScript -Command $Command -LogLines $LogLines

--- a/scripts/supervisor-windows.ps1
+++ b/scripts/supervisor-windows.ps1
@@ -33,8 +33,8 @@ $SkillDir   = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
 $RuntimeDir = Join-Path $CtiHome 'runtime'
 $PidFile    = Join-Path $RuntimeDir 'bridge.pid'
 $StatusFile = Join-Path $RuntimeDir 'status.json'
-$LogFile    = Join-Path $CtiHome 'logs' 'bridge.log'
-$DaemonMjs  = Join-Path $SkillDir 'dist' 'daemon.mjs'
+$LogFile    = Join-Path (Join-Path $CtiHome 'logs') 'bridge.log'
+$DaemonMjs  = Join-Path (Join-Path $SkillDir 'dist') 'daemon.mjs'
 
 $ServiceName = 'ClaudeToIMBridge'
 
@@ -72,9 +72,9 @@ function Read-Pid {
 }
 
 function Test-PidAlive {
-    param([string]$Pid)
-    if (-not $Pid) { return $false }
-    try { $null = Get-Process -Id ([int]$Pid) -ErrorAction Stop; return $true }
+    param([string]$ProcessIdValue)
+    if (-not $ProcessIdValue) { return $false }
+    try { $null = Get-Process -Id ([int]$ProcessIdValue) -ErrorAction Stop; return $true }
     catch { return $false }
 }
 
@@ -121,6 +121,12 @@ function Get-NodePath {
 
 function Find-ServiceManager {
     # Prefer WinSW, then NSSM
+    $localWinSW = Join-Path $SkillDir 'tools\WinSW.exe'
+    if (Test-Path $localWinSW) { return @{ type = 'winsw'; path = $localWinSW } }
+
+    $bundledWinSW = Join-Path $SkillDir "$ServiceName.exe"
+    if (Test-Path $bundledWinSW) { return @{ type = 'winsw'; path = $bundledWinSW } }
+
     $winsw = Get-Command 'WinSW.exe' -ErrorAction SilentlyContinue
     if ($winsw) { return @{ type = 'winsw'; path = $winsw.Source } }
 
@@ -135,11 +141,8 @@ function Install-WinSWService {
     $nodePath = Get-NodePath
     $xmlPath = Join-Path $SkillDir "$ServiceName.xml"
 
-    # Run as current user so the service can access ~/.claude-to-im and Codex login state
-    $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
-    Write-Host "Service will run as: $currentUser"
-    $cred = Get-Credential -UserName $currentUser -Message "Enter password for '$currentUser' (required for Windows Service logon)"
-    $plainPwd = $cred.GetNetworkCredential().Password
+    Write-Host "Service will run as: LocalSystem"
+    Write-Host "  USERPROFILE / APPDATA / LOCALAPPDATA are redirected to the current user's paths so Codex state remains available."
 
     # Generate WinSW config XML
     @"
@@ -150,11 +153,6 @@ function Install-WinSWService {
   <executable>$nodePath</executable>
   <arguments>$DaemonMjs</arguments>
   <workingdirectory>$SkillDir</workingdirectory>
-  <serviceaccount>
-    <username>$currentUser</username>
-    <password>$([System.Security.SecurityElement]::Escape($plainPwd))</password>
-    <allowservicelogon>true</allowservicelogon>
-  </serviceaccount>
   <env name="USERPROFILE" value="$env:USERPROFILE"/>
   <env name="APPDATA" value="$env:APPDATA"/>
   <env name="LOCALAPPDATA" value="$env:LOCALAPPDATA"/>
@@ -176,7 +174,7 @@ function Install-WinSWService {
 
     & $winswCopy install
     Write-Host "Service '$ServiceName' installed via WinSW."
-    Write-Host "  Service account: $currentUser"
+    Write-Host "  Service account: LocalSystem"
     Write-Host "Start with:  & `"$winswCopy`" start"
     Write-Host "Or:          sc.exe start $ServiceName"
 }
@@ -185,15 +183,11 @@ function Install-NSSMService {
     param([string]$NSSMPath)
     $nodePath = Get-NodePath
 
-    # Run as current user so the service can access ~/.claude-to-im and Codex login state
-    $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
-    Write-Host "Service will run as: $currentUser"
-    $cred = Get-Credential -UserName $currentUser -Message "Enter password for '$currentUser' (required for Windows Service logon)"
-    $plainPwd = $cred.GetNetworkCredential().Password
+    Write-Host "Service will run as: LocalSystem"
+    Write-Host "  USERPROFILE / APPDATA / LOCALAPPDATA are redirected to the current user's paths so Codex state remains available."
 
     & $NSSMPath install $ServiceName $nodePath $DaemonMjs
     & $NSSMPath set $ServiceName AppDirectory $SkillDir
-    & $NSSMPath set $ServiceName ObjectName $currentUser $plainPwd
     & $NSSMPath set $ServiceName AppStdout $LogFile
     & $NSSMPath set $ServiceName AppStderr $LogFile
     & $NSSMPath set $ServiceName AppStdoutCreationDisposition 4
@@ -203,7 +197,7 @@ function Install-NSSMService {
     & $NSSMPath set $ServiceName AppEnvironmentExtra "USERPROFILE=$env:USERPROFILE" "APPDATA=$env:APPDATA" "LOCALAPPDATA=$env:LOCALAPPDATA" "CTI_HOME=$CtiHome"
 
     Write-Host "Service '$ServiceName' installed via NSSM."
-    Write-Host "  Service account: $currentUser"
+    Write-Host "  Service account: LocalSystem"
     Write-Host "Start with:  nssm start $ServiceName"
     Write-Host "Or:          sc.exe start $ServiceName"
 }
@@ -267,7 +261,7 @@ switch ($Command) {
             }
         } else {
             Write-Host "Starting bridge (background process)..."
-            $pid = Start-Fallback
+            $bridgePid = Start-Fallback
             Start-Sleep -Seconds 3
 
             $newPid = Read-Pid
@@ -294,10 +288,10 @@ switch ($Command) {
             Write-Host "Bridge stopped"
             if (Test-Path $PidFile) { Remove-Item $PidFile -Force }
         } else {
-            $pid = Read-Pid
-            if (-not $pid) { Write-Host "No bridge running"; exit 0 }
-            if (Test-PidAlive $pid) {
-                Stop-Process -Id ([int]$pid) -Force
+            $bridgePid = Read-Pid
+            if (-not $bridgePid) { Write-Host "No bridge running"; exit 0 }
+            if (Test-PidAlive $bridgePid) {
+                Stop-Process -Id ([int]$bridgePid) -Force
                 Write-Host "Bridge stopped"
             } else {
                 Write-Host "Bridge was not running (stale PID file)"
@@ -307,7 +301,7 @@ switch ($Command) {
     }
 
     'status' {
-        $pid = Read-Pid
+        $bridgePid = Read-Pid
 
         # Check Windows Service
         $svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
@@ -315,8 +309,8 @@ switch ($Command) {
             Write-Host "Windows Service '$ServiceName': $($svc.Status)"
         }
 
-        if ($pid -and (Test-PidAlive $pid)) {
-            Write-Host "Bridge process is running (PID: $pid)"
+        if ($bridgePid -and (Test-PidAlive $bridgePid)) {
+            Write-Host "Bridge process is running (PID: $bridgePid)"
             if (Test-StatusRunning) {
                 Write-Host "Bridge status: running"
             } else {

--- a/scripts/tune-windows-service.ps1
+++ b/scripts/tune-windows-service.ps1
@@ -1,0 +1,31 @@
+param(
+    [string]$ServiceName = 'ClaudeToIMBridge'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).
+    IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+if (-not $isAdmin) {
+    throw "This script must be run in an Administrator PowerShell session."
+}
+
+Write-Host "== Current Service Config =="
+sc.exe qc $ServiceName
+
+Write-Host ""
+Write-Host "== Applying Delayed Auto Start =="
+sc.exe config $ServiceName start= delayed-auto
+
+Write-Host ""
+Write-Host "== Applying Network Dependencies =="
+sc.exe config $ServiceName depend= Dnscache/Tcpip
+
+Write-Host ""
+Write-Host "== Updated Service Config =="
+sc.exe qc $ServiceName
+
+Write-Host ""
+Write-Host "== Updated Delayed Auto Start Flag =="
+Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\$ServiceName" | Select-Object DelayedAutoStart


### PR DESCRIPTION
## Summary

This PR improves the Windows service workflow for `claude-to-im` when running under WinSW.

## Changes

- fix argument passing in `scripts/daemon.ps1`
- fix Windows path joining issues in `scripts/supervisor-windows.ps1`
- avoid PowerShell `$PID` variable conflicts
- prefer local `tools/WinSW.exe` when available
- run WinSW/NSSM service with `LocalSystem` plus explicit user environment paths
- add `scripts/check-windows-service.ps1` for diagnostics
- add `scripts/tune-windows-service.ps1` for delayed auto-start and network dependencies

## Why

These changes make Windows service startup and troubleshooting more reliable, especially for Codex + Feishu usage and boot-time auto-start scenarios.
