### PR TITLE
Fix Windows bridge scripts and Codex git-skip wiring

### DIFF
--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -1,0 +1,495 @@
+<#
+.SYNOPSIS
+  Windows diagnostics for the claude-to-im bridge.
+
+.DESCRIPTION
+  Validates the local Windows environment without relying on bash/WSL semantics.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$CtiHome    = if ($env:CTI_HOME) { $env:CTI_HOME } else { Join-Path $env:USERPROFILE '.claude-to-im' }
+$SkillDir   = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+$ConfigFile = Join-Path $CtiHome 'config.env'
+$RuntimeDir = Join-Path $CtiHome 'runtime'
+$PidFile    = Join-Path $RuntimeDir 'bridge.pid'
+$StatusFile = Join-Path $RuntimeDir 'status.json'
+$LogDir     = Join-Path $CtiHome 'logs'
+$LogFile    = Join-Path $LogDir 'bridge.log'
+$DaemonMjs  = Join-Path (Join-Path $SkillDir 'dist') 'daemon.mjs'
+
+$Pass = 0
+$Fail = 0
+
+function Add-Result {
+    param(
+        [string]$Label,
+        [bool]$Ok
+    )
+
+    if ($Ok) {
+        Write-Host "[OK]   $Label"
+        $script:Pass++
+    } else {
+        Write-Host "[FAIL] $Label"
+        $script:Fail++
+    }
+}
+
+function Get-ConfigMap {
+    $map = @{}
+    if (-not (Test-Path $ConfigFile)) {
+        return $map
+    }
+
+    $raw = [System.IO.File]::ReadAllText($ConfigFile)
+    if ($raw.Length -gt 0 -and $raw[0] -eq [char]0xFEFF) {
+        $raw = $raw.Substring(1)
+    }
+
+    foreach ($line in ($raw -split "`r?`n")) {
+        $trimmed = $line.Trim()
+        if (-not $trimmed -or $trimmed.StartsWith('#')) {
+            continue
+        }
+
+        $sep = $trimmed.IndexOf('=')
+        if ($sep -lt 1) {
+            continue
+        }
+
+        $key = $trimmed.Substring(0, $sep).Trim()
+        $value = $trimmed.Substring($sep + 1).Trim()
+        if (
+            $value.Length -ge 2 -and
+            (($value.StartsWith('"') -and $value.EndsWith('"')) -or ($value.StartsWith("'") -and $value.EndsWith("'")))
+        ) {
+            $value = $value.Substring(1, $value.Length - 2)
+        }
+
+        $map[$key] = $value
+    }
+
+    return $map
+}
+
+function Get-ConfigValue {
+    param(
+        [hashtable]$Config,
+        [string]$Key,
+        [string]$Default = ''
+    )
+
+    if ($Config.ContainsKey($Key) -and $null -ne $Config[$Key] -and $Config[$Key] -ne '') {
+        return $Config[$Key]
+    }
+
+    return $Default
+}
+
+function Test-CodexAuthFile {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return $false
+    }
+
+    try {
+        $raw = Get-Content $Path -Raw
+        if (-not $raw) {
+            return $false
+        }
+
+        $auth = $raw | ConvertFrom-Json
+        return [string]::IsNullOrWhiteSpace($auth.OPENAI_API_KEY) -eq $false
+    } catch {
+        return $false
+    }
+}
+
+function Test-PidAlive {
+    param([string]$Pid)
+    if (-not $Pid) {
+        return $false
+    }
+
+    try {
+        $null = Get-Process -Id ([int]$Pid) -ErrorAction Stop
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+function Get-EnabledChannels {
+    param([hashtable]$Config)
+
+    $value = Get-ConfigValue -Config $Config -Key 'CTI_ENABLED_CHANNELS'
+    if (-not $value) {
+        return @()
+    }
+
+    return @(
+        $value.Split(',') |
+        ForEach-Object { $_.Trim().ToLowerInvariant() } |
+        Where-Object { $_ }
+    )
+}
+
+function Test-FileAcl {
+    param([string]$Path)
+
+    try {
+        $acl = Get-Acl $Path
+        $broadWriters = @(
+            $acl.Access | Where-Object {
+                $_.AccessControlType -eq 'Allow' -and
+                $_.IdentityReference.Value -match '(^|\\)(Everyone|Users|Authenticated Users)$' -and
+                (
+                    ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::WriteData) -or
+                    ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::CreateFiles) -or
+                    ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::Modify) -or
+                    ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl)
+                )
+            }
+        )
+
+        if ($broadWriters.Count -eq 0) {
+            Add-Result "config.env ACL is not broadly writable" $true
+        } else {
+            $principals = ($broadWriters | Select-Object -ExpandProperty IdentityReference -Unique) -join ', '
+            Add-Result "config.env ACL is not broadly writable (write access for: $principals)" $false
+        }
+    } catch {
+        Add-Result "config.env ACL check completed" $false
+    }
+}
+
+function Invoke-JsonPost {
+    param(
+        [string]$Uri,
+        [hashtable]$Body,
+        [hashtable]$Headers = @{}
+    )
+
+    return Invoke-RestMethod -Uri $Uri -Method Post -Headers $Headers -Body ($Body | ConvertTo-Json -Compress) -ContentType 'application/json' -TimeoutSec 10
+}
+
+$config = Get-ConfigMap
+
+$nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+if ($nodeCmd) {
+    $nodeVersionText = (& $nodeCmd.Source --version 2>$null).Trim()
+    $nodeVersion = $null
+    if ([Version]::TryParse(($nodeVersionText -replace '^v', ''), [ref]$nodeVersion)) {
+        Add-Result "Node.js >= 20 (found $nodeVersionText)" ($nodeVersion.Major -ge 20)
+    } else {
+        Add-Result "Node.js version readable (found $nodeVersionText)" $false
+    }
+} else {
+    Add-Result "Node.js installed" $false
+}
+
+$runtime = Get-ConfigValue -Config $config -Key 'CTI_RUNTIME' -Default 'claude'
+Write-Host "Runtime: $runtime"
+Write-Host ""
+
+if ($runtime -in @('claude', 'auto')) {
+    $claudeCandidates = New-Object System.Collections.Generic.List[string]
+    $explicitClaudePath = Get-ConfigValue -Config $config -Key 'CTI_CLAUDE_CODE_EXECUTABLE'
+    if ($explicitClaudePath) {
+        $claudeCandidates.Add($explicitClaudePath)
+    } else {
+        @(Get-Command claude -All -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -Unique) | ForEach-Object {
+            if ($_ -and -not $claudeCandidates.Contains($_)) {
+                $claudeCandidates.Add($_)
+            }
+        }
+
+        @(
+            (Join-Path $env:USERPROFILE '.claude\local\claude.exe'),
+            (Join-Path $env:USERPROFILE '.local\bin\claude'),
+            'C:\Program Files\Claude\claude.exe'
+        ) | ForEach-Object {
+            if ($_ -and (Test-Path $_) -and -not $claudeCandidates.Contains($_)) {
+                $claudeCandidates.Add($_)
+            }
+        }
+    }
+
+    $claudeOk = $false
+    $claudeSummary = $null
+    foreach ($candidate in $claudeCandidates) {
+        try {
+            $verText = (& $candidate --version 2>$null).Trim()
+            $verObj = $null
+            if (-not [Version]::TryParse(($verText -replace '^v', ''), [ref]$verObj)) {
+                continue
+            }
+            if ($verObj.Major -lt 2) {
+                $claudeSummary = "$candidate is too old ($verText)"
+                continue
+            }
+
+            $helpText = (& $candidate --help 2>&1 | Out-String)
+            $missingFlags = @('output-format', 'input-format', 'permission-mode', 'setting-sources') | Where-Object {
+                $helpText -notmatch [regex]::Escape($_)
+            }
+
+            if ($missingFlags.Count -eq 0) {
+                $claudeOk = $true
+                $claudeSummary = "$verText at $candidate"
+                break
+            }
+
+            $claudeSummary = "$candidate missing flags: $($missingFlags -join ', ')"
+        } catch {
+            $claudeSummary = "$candidate could not be executed"
+        }
+    }
+
+    if ($claudeOk) {
+        Add-Result "Claude CLI compatible ($claudeSummary)" $true
+        $hasThirdPartyAuth = $config.Keys | Where-Object { $_ -in @('ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN') }
+        if ($hasThirdPartyAuth) {
+            Add-Result "Claude CLI auth (skipped: ANTHROPIC_* configured in config.env)" $true
+        } else {
+            $claudeAuthOk = $false
+            try {
+                $authText = (& claude auth status 2>&1 | Out-String)
+                $claudeAuthOk = $authText -match 'loggedIn.*true|logged in|authenticated'
+            } catch {
+                $claudeAuthOk = $false
+            }
+            Add-Result "Claude CLI authenticated" $claudeAuthOk
+        }
+    } else {
+        $label = if ($claudeSummary) { "Claude CLI compatible ($claudeSummary)" } else { 'Claude CLI compatible (not found)' }
+        Add-Result $label ($runtime -eq 'auto')
+    }
+
+    $sdkCliPaths = @(
+        (Join-Path $SkillDir 'node_modules\@anthropic-ai\claude-agent-sdk\cli.js'),
+        (Join-Path $SkillDir 'node_modules\@anthropic-ai\claude-agent-sdk\dist\cli.js')
+    )
+    $sdkCli = $sdkCliPaths | Where-Object { Test-Path $_ } | Select-Object -First 1
+    $sdkLabel = if ($sdkCli) { "Claude SDK cli.js exists ($sdkCli)" } else { "Claude SDK cli.js exists (not found)" }
+    Add-Result $sdkLabel ($sdkCli -or $runtime -ne 'claude')
+}
+
+if ($runtime -in @('codex', 'auto')) {
+    $codexCmd = Get-Command codex -ErrorAction SilentlyContinue
+    $codexAuthFile = Join-Path $env:USERPROFILE '.codex\auth.json'
+    if ($codexCmd) {
+        $codexVersion = (& $codexCmd.Source --version 2>$null | Select-Object -First 1)
+        if (-not $codexVersion) {
+            $codexVersion = 'unknown'
+        }
+        Add-Result "Codex CLI available ($codexVersion)" $true
+    } else {
+        Add-Result "Codex CLI available (not found in PATH)" ($runtime -eq 'auto')
+    }
+
+    $codexSdk = Join-Path $SkillDir 'node_modules\@openai\codex-sdk'
+    $codexSdkExists = Test-Path $codexSdk
+    $codexSdkLabel = if ($codexSdkExists) { '@openai/codex-sdk installed' } else { "@openai/codex-sdk installed (not found in $codexSdk)" }
+    Add-Result $codexSdkLabel ($codexSdkExists -or $runtime -ne 'codex')
+
+    $codexAuthOk = $false
+    if (
+        (Get-ConfigValue -Config $config -Key 'CTI_CODEX_API_KEY') -or
+        $env:CTI_CODEX_API_KEY -or
+        $env:CODEX_API_KEY -or
+        $env:OPENAI_API_KEY
+    ) {
+        $codexAuthOk = $true
+    } elseif (Test-CodexAuthFile -Path $codexAuthFile) {
+        $codexAuthOk = $true
+    } elseif ($codexCmd) {
+        try {
+            $authText = (& $codexCmd.Source login --help 2>&1 | Out-String)
+            $codexAuthOk = $authText -match 'logout'
+        } catch {
+            $codexAuthOk = $false
+        }
+    }
+    Add-Result "Codex auth available (API key or codex auth login)" ($codexAuthOk -or $runtime -ne 'codex')
+}
+
+if (Test-Path $DaemonMjs) {
+    $bundleTime = (Get-Item $DaemonMjs).LastWriteTimeUtc
+    $sources = @()
+    if (Test-Path (Join-Path $SkillDir 'src')) {
+        $sources += Get-ChildItem -Path (Join-Path $SkillDir 'src') -Filter '*.ts' -Recurse
+    }
+    if (Test-Path (Join-Path $SkillDir 'node_modules\claude-to-im\src')) {
+        $sources += Get-ChildItem -Path (Join-Path $SkillDir 'node_modules\claude-to-im\src') -Filter '*.ts' -Recurse
+    }
+    $staleSource = $sources | Where-Object { $_.LastWriteTimeUtc -gt $bundleTime } | Select-Object -First 1
+    $daemonLabel = if ($staleSource) { "dist/daemon.mjs is up to date (stale source: $($staleSource.FullName))" } else { 'dist/daemon.mjs is up to date' }
+    Add-Result $daemonLabel (-not $staleSource)
+} else {
+    Add-Result "dist/daemon.mjs exists" $false
+}
+
+Add-Result "config.env exists" (Test-Path $ConfigFile)
+if (Test-Path $ConfigFile) {
+    Test-FileAcl -Path $ConfigFile
+}
+
+$channels = Get-EnabledChannels -Config $config
+
+if ($channels -contains 'telegram') {
+    $tgToken = Get-ConfigValue -Config $config -Key 'CTI_TG_BOT_TOKEN'
+    if ($tgToken) {
+        try {
+            $tgResult = Invoke-RestMethod -Uri "https://api.telegram.org/bot$tgToken/getMe" -Method Get -TimeoutSec 10
+            Add-Result "Telegram bot token is valid" ($tgResult.ok -eq $true)
+        } catch {
+            Add-Result "Telegram bot token is valid" $false
+        }
+    } else {
+        Add-Result "Telegram bot token configured" $false
+    }
+}
+
+if ($channels -contains 'feishu') {
+    $fsAppId = Get-ConfigValue -Config $config -Key 'CTI_FEISHU_APP_ID'
+    $fsSecret = Get-ConfigValue -Config $config -Key 'CTI_FEISHU_APP_SECRET'
+    $fsDomain = Get-ConfigValue -Config $config -Key 'CTI_FEISHU_DOMAIN' -Default 'https://open.feishu.cn'
+    if ($fsAppId -and $fsSecret) {
+        try {
+            $fsResult = Invoke-JsonPost -Uri "$fsDomain/open-apis/auth/v3/tenant_access_token/internal" -Body @{
+                app_id = $fsAppId
+                app_secret = $fsSecret
+            }
+            Add-Result "Feishu app credentials are valid" ($fsResult.code -eq 0)
+        } catch {
+            Add-Result "Feishu app credentials are valid" $false
+        }
+    } else {
+        Add-Result "Feishu app credentials configured" $false
+    }
+}
+
+if ($channels -contains 'qq') {
+    $qqAppId = Get-ConfigValue -Config $config -Key 'CTI_QQ_APP_ID'
+    $qqAppSecret = Get-ConfigValue -Config $config -Key 'CTI_QQ_APP_SECRET'
+    if ($qqAppId -and $qqAppSecret) {
+        try {
+            $qqTokenResult = Invoke-JsonPost -Uri 'https://bots.qq.com/app/getAppAccessToken' -Body @{
+                appId = $qqAppId
+                clientSecret = $qqAppSecret
+            }
+            $qqAccessToken = $qqTokenResult.access_token
+            Add-Result "QQ app credentials are valid" ([string]::IsNullOrWhiteSpace($qqAccessToken) -eq $false)
+            if ($qqAccessToken) {
+                try {
+                    $qqGateway = Invoke-RestMethod -Uri 'https://api.sgroup.qq.com/gateway' -Headers @{
+                        Authorization = "QQBot $qqAccessToken"
+                    } -Method Get -TimeoutSec 10
+                    Add-Result "QQ gateway is reachable" ($null -ne $qqGateway.url)
+                } catch {
+                    Add-Result "QQ gateway is reachable" $false
+                }
+            }
+        } catch {
+            Add-Result "QQ app credentials are valid" $false
+        }
+    } else {
+        Add-Result "QQ app credentials configured" $false
+    }
+}
+
+if ($channels -contains 'discord') {
+    $discordToken = Get-ConfigValue -Config $config -Key 'CTI_DISCORD_BOT_TOKEN'
+    if ($discordToken) {
+        Add-Result "Discord bot token format" ($discordToken -match '^[A-Za-z0-9_-]{20,}\.')
+    } else {
+        Add-Result "Discord bot token configured" $false
+    }
+}
+
+if ($channels -contains 'weixin') {
+    $weixinAccountsFile = Join-Path (Join-Path $CtiHome 'data') 'weixin-accounts.json'
+    if (Test-Path $weixinAccountsFile) {
+        try {
+            $accounts = Get-Content $weixinAccountsFile -Raw | ConvertFrom-Json
+            if ($null -eq $accounts) {
+                $accounts = @()
+            } elseif ($accounts -isnot [System.Collections.IEnumerable] -or $accounts -is [string]) {
+                $accounts = @($accounts)
+            }
+
+            $enabledAccounts = @($accounts | Where-Object { $_.enabled -and $_.token })
+            if ($enabledAccounts.Count -ge 1) {
+                if ($accounts.Count -gt 1) {
+                    Add-Result "Weixin linked account store is ready ($($accounts.Count) records; newest enabled account will be used)" $true
+                } else {
+                    Add-Result "Weixin linked account store is ready" $true
+                }
+            } else {
+                Add-Result "Weixin linked account store has an enabled account with token" $false
+            }
+        } catch {
+            Add-Result "Weixin linked account store is readable" $false
+        }
+    } else {
+        Add-Result "Weixin linked account store exists" $false
+    }
+}
+
+if (Test-Path $LogDir) {
+    try {
+        $tmpFile = Join-Path $LogDir ("doctor-write-test-{0}.tmp" -f [guid]::NewGuid().ToString('N'))
+        Set-Content -Path $tmpFile -Value 'ok' -Encoding ascii
+        Remove-Item $tmpFile -Force
+        Add-Result "Log directory is writable" $true
+    } catch {
+        Add-Result "Log directory is writable" $false
+    }
+} else {
+    Add-Result "Log directory exists" $false
+}
+
+$service = Get-Service -Name 'ClaudeToIMBridge' -ErrorAction SilentlyContinue
+if ($service) {
+    Add-Result "Windows Service registration is healthy ($($service.Status))" $true
+}
+
+if (Test-Path $PidFile) {
+    $pid = (Get-Content $PidFile -Raw).Trim()
+    Add-Result "PID file is consistent" (Test-PidAlive -Pid $pid)
+} else {
+    Add-Result "PID file consistency (no PID file, OK)" $true
+}
+
+if (Test-Path $LogFile) {
+    $recentErrors = @(
+        Get-Content $LogFile -Tail 50 |
+        Where-Object { $_ -match 'ERROR|Fatal' }
+    )
+    Add-Result "No recent errors in log (last 50 lines)" ($recentErrors.Count -eq 0)
+} else {
+    Add-Result "Log file exists (not yet created)" $true
+}
+
+Write-Host ""
+Write-Host "Results: $Pass passed, $Fail failed"
+
+if ($Fail -gt 0) {
+    Write-Host ""
+    Write-Host "Common fixes:"
+    Write-Host "  npm dependencies missing  -> cd `"$SkillDir`"; npm install"
+    Write-Host "  daemon bundle stale       -> cd `"$SkillDir`"; npm run build"
+    Write-Host "  config missing            -> create `"$ConfigFile`" from config.env.example"
+    Write-Host "  Codex auth missing        -> run `codex auth login` or set OPENAI_API_KEY"
+    Write-Host "  Weixin account missing    -> cd `"$SkillDir`"; npm run weixin:login"
+    Write-Host "  stale pid                 -> powershell -File `"$SkillDir\scripts\daemon.ps1`" stop"
+}
+
+if ($Fail -eq 0) {
+    exit 0
+}
+
+exit 1

--- a/scripts/supervisor-windows.ps1
+++ b/scripts/supervisor-windows.ps1
@@ -33,8 +33,9 @@ $SkillDir   = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
 $RuntimeDir = Join-Path $CtiHome 'runtime'
 $PidFile    = Join-Path $RuntimeDir 'bridge.pid'
 $StatusFile = Join-Path $RuntimeDir 'status.json'
-$LogFile    = Join-Path $CtiHome 'logs' 'bridge.log'
-$DaemonMjs  = Join-Path $SkillDir 'dist' 'daemon.mjs'
+$LogFile    = Join-Path (Join-Path $CtiHome 'logs') 'bridge.log'
+$ErrLogFile = Join-Path (Join-Path $CtiHome 'logs') 'bridge.err.log'
+$DaemonMjs  = Join-Path (Join-Path $SkillDir 'dist') 'daemon.mjs'
 
 $ServiceName = 'ClaudeToIMBridge'
 
@@ -72,9 +73,9 @@ function Read-Pid {
 }
 
 function Test-PidAlive {
-    param([string]$Pid)
-    if (-not $Pid) { return $false }
-    try { $null = Get-Process -Id ([int]$Pid) -ErrorAction Stop; return $true }
+    param([string]$ProcessId)
+    if (-not $ProcessId) { return $false }
+    try { $null = Get-Process -Id ([int]$ProcessId) -ErrorAction Stop; return $true }
     catch { return $false }
 }
 
@@ -98,6 +99,8 @@ function Show-FailureHelp {
     Write-Host "Recent logs:"
     if (Test-Path $LogFile) {
         Get-Content $LogFile -Tail 20
+    } elseif (Test-Path $ErrLogFile) {
+        Get-Content $ErrLogFile -Tail 20
     } else {
         Write-Host "  (no log file)"
     }
@@ -226,7 +229,7 @@ function Start-Fallback {
         -WorkingDirectory $SkillDir `
         -WindowStyle Hidden `
         -RedirectStandardOutput $LogFile `
-        -RedirectStandardError $LogFile `
+        -RedirectStandardError $ErrLogFile `
         -PassThru
 
     # Write initial PID (main.ts will overwrite with real PID)
@@ -267,16 +270,16 @@ switch ($Command) {
             }
         } else {
             Write-Host "Starting bridge (background process)..."
-            $pid = Start-Fallback
+            $bridgePid = Start-Fallback
             Start-Sleep -Seconds 3
 
-            $newPid = Read-Pid
-            if ($newPid -and (Test-PidAlive $newPid) -and (Test-StatusRunning)) {
-                Write-Host "Bridge started (PID: $newPid)"
+            $newBridgePid = Read-Pid
+            if ($newBridgePid -and (Test-PidAlive $newBridgePid) -and (Test-StatusRunning)) {
+                Write-Host "Bridge started (PID: $newBridgePid)"
                 if (Test-Path $StatusFile) { Get-Content $StatusFile -Raw }
             } else {
                 Write-Host "Failed to start bridge."
-                if (-not $newPid -or -not (Test-PidAlive $newPid)) {
+                if (-not $newBridgePid -or -not (Test-PidAlive $newBridgePid)) {
                     Write-Host "  Process exited immediately."
                 }
                 Show-LastExitReason
@@ -294,10 +297,10 @@ switch ($Command) {
             Write-Host "Bridge stopped"
             if (Test-Path $PidFile) { Remove-Item $PidFile -Force }
         } else {
-            $pid = Read-Pid
-            if (-not $pid) { Write-Host "No bridge running"; exit 0 }
-            if (Test-PidAlive $pid) {
-                Stop-Process -Id ([int]$pid) -Force
+            $bridgePid = Read-Pid
+            if (-not $bridgePid) { Write-Host "No bridge running"; exit 0 }
+            if (Test-PidAlive $bridgePid) {
+                Stop-Process -Id ([int]$bridgePid) -Force
                 Write-Host "Bridge stopped"
             } else {
                 Write-Host "Bridge was not running (stale PID file)"
@@ -307,7 +310,7 @@ switch ($Command) {
     }
 
     'status' {
-        $pid = Read-Pid
+        $bridgePid = Read-Pid
 
         # Check Windows Service
         $svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
@@ -315,8 +318,8 @@ switch ($Command) {
             Write-Host "Windows Service '$ServiceName': $($svc.Status)"
         }
 
-        if ($pid -and (Test-PidAlive $pid)) {
-            Write-Host "Bridge process is running (PID: $pid)"
+        if ($bridgePid -and (Test-PidAlive $bridgePid)) {
+            Write-Host "Bridge process is running (PID: $bridgePid)"
             if (Test-StatusRunning) {
                 Write-Host "Bridge status: running"
             } else {
@@ -331,11 +334,20 @@ switch ($Command) {
     }
 
     'logs' {
+        $hasLogs = $false
         if (Test-Path $LogFile) {
+            $hasLogs = $true
             Get-Content $LogFile -Tail $LogLines | ForEach-Object {
                 $_ -replace '(token|secret|password)(["'']?\s*[:=]\s*["'']?)[^\s"]+', '$1$2*****'
             }
-        } else {
+        }
+        if (Test-Path $ErrLogFile) {
+            $hasLogs = $true
+            Get-Content $ErrLogFile -Tail $LogLines | ForEach-Object {
+                $_ -replace '(token|secret|password)(["'']?\s*[:=]\s*["'']?)[^\s"]+', '$1$2*****'
+            }
+        }
+        if (-not $hasLogs) {
             Write-Host "No log file found at $LogFile"
         }
     }

--- a/src/codex-provider.ts
+++ b/src/codex-provider.ts
@@ -56,10 +56,6 @@ function shouldPassModelToCodex(): boolean {
 }
 
 /** Allow Codex to run outside a trusted Git repository when explicitly enabled. */
-function shouldSkipGitRepoCheck(): boolean {
-  return process.env.CTI_CODEX_SKIP_GIT_REPO_CHECK === 'true';
-}
-
 function shouldRetryFreshThread(message: string): boolean {
   const lower = message.toLowerCase();
   return (
@@ -76,7 +72,10 @@ export class CodexProvider implements LLMProvider {
   /** Maps session IDs to Codex thread IDs for resume. */
   private threadIds = new Map<string, string>();
 
-  constructor(private pendingPerms: PendingPermissions) {}
+  constructor(
+    private pendingPerms: PendingPermissions,
+    private skipGitRepoCheck = false,
+  ) {}
 
   /**
    * Lazily load the Codex SDK. Throws a clear error if not installed.
@@ -131,7 +130,7 @@ export class CodexProvider implements LLMProvider {
             const threadOptions: Record<string, unknown> = {
               ...(passModel && params.model ? { model: params.model } : {}),
               ...(params.workingDirectory ? { workingDirectory: params.workingDirectory } : {}),
-              ...(shouldSkipGitRepoCheck() ? { skipGitRepoCheck: true } : {}),
+              ...(self.skipGitRepoCheck ? { skipGitRepoCheck: true } : {}),
               approvalPolicy,
             };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export interface Config {
   defaultWorkDir: string;
   defaultModel?: string;
   defaultMode: string;
+  codexSkipGitRepoCheck?: boolean;
   // Telegram
   tgBotToken?: string;
   tgChatId?: string;
@@ -86,6 +87,7 @@ export function loadConfig(): Config {
     defaultWorkDir: env.get("CTI_DEFAULT_WORKDIR") || process.cwd(),
     defaultModel: env.get("CTI_DEFAULT_MODEL") || undefined,
     defaultMode: env.get("CTI_DEFAULT_MODE") || "code",
+    codexSkipGitRepoCheck: env.get("CTI_CODEX_SKIP_GIT_REPO_CHECK") === "true",
     tgBotToken: env.get("CTI_TG_BOT_TOKEN") || undefined,
     tgChatId: env.get("CTI_TG_CHAT_ID") || undefined,
     tgAllowedUsers: splitCsv(env.get("CTI_TG_ALLOWED_USERS")),
@@ -132,6 +134,11 @@ export function saveConfig(config: Config): void {
   out += formatEnvLine("CTI_DEFAULT_WORKDIR", config.defaultWorkDir);
   if (config.defaultModel) out += formatEnvLine("CTI_DEFAULT_MODEL", config.defaultModel);
   out += formatEnvLine("CTI_DEFAULT_MODE", config.defaultMode);
+  if (config.codexSkipGitRepoCheck !== undefined)
+    out += formatEnvLine(
+      "CTI_CODEX_SKIP_GIT_REPO_CHECK",
+      String(config.codexSkipGitRepoCheck)
+    );
   out += formatEnvLine("CTI_TG_BOT_TOKEN", config.tgBotToken);
   out += formatEnvLine("CTI_TG_CHAT_ID", config.tgChatId);
   out += formatEnvLine(

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,7 @@ async function resolveProvider(config: Config, pendingPerms: PendingPermissions)
 
   if (runtime === 'codex') {
     const { CodexProvider } = await import('./codex-provider.js');
-    return new CodexProvider(pendingPerms);
+    return new CodexProvider(pendingPerms, config.codexSkipGitRepoCheck);
   }
 
   if (runtime === 'auto') {
@@ -58,7 +58,7 @@ async function resolveProvider(config: Config, pendingPerms: PendingPermissions)
       console.log('[claude-to-im] Auto: Claude CLI not found, falling back to Codex');
     }
     const { CodexProvider } = await import('./codex-provider.js');
-    return new CodexProvider(pendingPerms);
+    return new CodexProvider(pendingPerms, config.codexSkipGitRepoCheck);
   }
 
   // Default: claude

--- a/src/weixin-login.ts
+++ b/src/weixin-login.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import QRCode from 'qrcode';
 import { CTI_HOME, loadConfig } from './config.js';
 import { startLoginQr, pollLoginQrStatus } from './adapters/weixin/weixin-api.js';
@@ -263,7 +264,7 @@ export async function runWeixinLogin(): Promise<{ accountId: string; htmlPath: s
 
 const isMainModule = (() => {
   const entry = process.argv[1];
-  return !!entry && path.resolve(entry) === path.resolve(new URL(import.meta.url).pathname);
+  return !!entry && path.resolve(entry) === path.resolve(fileURLToPath(import.meta.url));
 })();
 
 if (isMainModule) {


### PR DESCRIPTION
## Summary

  This PR fixes several real Windows issues in the bridge and wires `CTI_CODEX_SKIP_GIT_REPO_CHECK` through to the Codex runtime correctly.

  ## Changes

  - Fix `src/weixin-login.ts` main-module detection on Windows by switching to `fileURLToPath(import.meta.url)`
  - Wire `CTI_CODEX_SKIP_GIT_REPO_CHECK` through `src/config.ts` -> `src/main.ts` -> `src/codex-provider.ts`
  - Fix a real bug in `src/codex-provider.ts` where `skipGitRepoCheck` was read from the wrong `this` context, so it was never actually passed to the Codex SDK
  - Fix multiple PowerShell 5 compatibility issues in `scripts/supervisor-windows.ps1`
    - invalid `Join-Path` usage
    - conflict with built-in `$Pid`
    - invalid stdout/stderr redirection to the same file
    - improve stderr log visibility
  - Add `scripts/doctor.ps1` for Windows diagnostics

  ## Why

  On Windows, these issues can break the bridge in practice:

  - `npm run weixin:login` may exit immediately
  - daemon management scripts may fail
  - users can still hit:
    `Not inside a trusted directory and --skip-git-repo-check was not specified.`
    even when `CTI_CODEX_SKIP_GIT_REPO_CHECK=true` is configured

  ## Validation

  Verified locally on Windows with:

  - `npm run build`
  - successful Weixin QR login
  - working daemon `start / status / logs / stop`
  - successful CodexProvider execution with `skipGitRepoCheck` enabled

  ## Notes

  This PR does not include any local runtime data such as config, sessions, logs, or account data.