### PR TITLE
Add WeChat workspace switching and harden Codex bridge stability

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -120,6 +120,24 @@ Ask for runtime, default working directory, model, and mode:
   - `codex` — uses OpenAI Codex SDK (requires `codex` CLI; auth via `codex auth login` or `OPENAI_API_KEY`)
   - `auto` — tries Claude first, falls back to Codex if Claude CLI not found
 - **Working Directory**: default `$CWD`
+- **Workspace whitelist** (optional, recommended for Weixin multi-project use):
+  - `CTI_DEFAULT_WORKDIR` remains the global fallback working directory
+  - If the user wants to switch between multiple projects from WeChat, create `~/.claude-to-im/workspaces.json`
+  - Format:
+    ```json
+    {
+      "defaultAlias": "zero",
+      "workspaces": [
+        { "alias": "zero", "path": "/absolute/path/to/project-zero" },
+        { "alias": "foo", "path": "/absolute/path/to/project-foo" }
+      ]
+    }
+    ```
+  - WeChat control commands:
+    - `项目列表`
+    - `当前项目`
+    - `切换项目 <alias>`
+  - Only whitelist aliases are allowed; arbitrary path switching is intentionally blocked
 - **Model** (optional): Leave blank to inherit the runtime's own default model. If the user wants to override, ask them to enter a model name. Do NOT hardcode or suggest specific model names — the available models change over time.
 - **Mode**: `code` (default), `plan`, `ask`
 
@@ -177,8 +195,10 @@ Show results and suggest fixes for any failures. Common fixes:
 - SDK cli.js missing → `cd SKILL_DIR && npm install`
 - dist/daemon.mjs stale → `cd SKILL_DIR && npm run build`
 - Config missing → run `setup`
+- Workspace whitelist invalid → fix `~/.claude-to-im/workspaces.json` (duplicate alias, missing default alias, non-existent path, or non-absolute path)
 - Weixin account missing / expired → `cd SKILL_DIR && npm run weixin:login`
 - Weixin voice message reports missing speech-to-text → enable WeChat's own voice transcription and resend; the bridge does not transcribe raw voice audio itself
+- Codex bridge hangs after `thread.started` or logs interactive MCP auth errors (for example Figma) → keep the default isolated bridge `CODEX_HOME`; do not set `CTI_CODEX_USE_SHARED_HOME=true` unless you explicitly want the bridge to inherit your main `~/.codex/config.toml`
 
 For more complex issues (messages not received, permission timeouts, high memory, stale PID files), read `SKILL_DIR/references/troubleshooting.md` for detailed diagnosis steps.
 

--- a/config.env.example
+++ b/config.env.example
@@ -13,6 +13,20 @@ CTI_ENABLED_CHANNELS=telegram
 # Default working directory for Claude Code sessions
 CTI_DEFAULT_WORKDIR=/path/to/your/project
 
+# Optional multi-project whitelist for WeChat project switching:
+# create ~/.claude-to-im/workspaces.json with content like:
+# {
+#   "defaultAlias": "zero",
+#   "workspaces": [
+#     { "alias": "zero", "path": "/absolute/path/to/project-zero" },
+#     { "alias": "foo", "path": "/absolute/path/to/project-foo" }
+#   ]
+# }
+# When configured, WeChat supports:
+#   项目列表
+#   当前项目
+#   切换项目 <alias>
+
 # Default model (optional — inherits from runtime's own default if not set)
 # CTI_DEFAULT_MODEL=
 
@@ -37,6 +51,13 @@ CTI_DEFAULT_MODE=code
 # Priority: CTI_CODEX_API_KEY > CODEX_API_KEY > OPENAI_API_KEY
 # CTI_CODEX_API_KEY=
 # CTI_CODEX_BASE_URL=
+# By default the bridge runs Codex with an isolated CODEX_HOME under
+# ~/.claude-to-im/codex-home so background replies are not blocked by
+# interactive MCP servers from ~/.codex/config.toml (for example Figma auth).
+# Set this only if you intentionally want the bridge to reuse your main Codex config.
+# CTI_CODEX_USE_SHARED_HOME=true
+# Fail a turn if Codex stops emitting follow-up events for too long (default 45000 ms).
+# CTI_CODEX_STREAM_IDLE_TIMEOUT_MS=45000
 # Allow Codex to run when CTI_DEFAULT_WORKDIR is not inside a trusted Git repo.
 # Keep this off unless you intentionally want Codex to work in arbitrary folders.
 # CTI_CODEX_SKIP_GIT_REPO_CHECK=true

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "node scripts/build.js",
     "typecheck": "tsc --noEmit",
     "dev": "tsx src/main.ts",
-    "weixin:login": "node --import tsx src/weixin-login.ts",
+    "weixin:login": "node dist/weixin-login.mjs",
     "test": "CTI_HOME=$(mktemp -d) node --test --test-concurrency=1 --import tsx --test-timeout=15000 src/__tests__/*.test.ts"
   },
   "dependencies": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,12 +1,10 @@
 import * as esbuild from 'esbuild';
 
-await esbuild.build({
-  entryPoints: ['src/main.ts'],
+const sharedOptions = {
   bundle: true,
   platform: 'node',
   format: 'esm',
   target: 'node20',
-  outfile: 'dist/daemon.mjs',
   external: [
     // SDK must stay external — it spawns a CLI subprocess and resolves
     // dist/cli.js relative to its own package location. Bundling it
@@ -21,6 +19,19 @@ await esbuild.build({
     'node:*',
   ],
   banner: { js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);" },
+};
+
+await esbuild.build({
+  ...sharedOptions,
+  entryPoints: ['src/main.ts'],
+  outfile: 'dist/daemon.mjs',
+});
+
+await esbuild.build({
+  ...sharedOptions,
+  entryPoints: ['src/weixin-login.ts'],
+  outfile: 'dist/weixin-login.mjs',
 });
 
 console.log('Built dist/daemon.mjs');
+console.log('Built dist/weixin-login.mjs');

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -4,6 +4,7 @@ CTI_HOME="$HOME/.claude-to-im"
 CONFIG_FILE="$CTI_HOME/config.env"
 PID_FILE="$CTI_HOME/runtime/bridge.pid"
 LOG_FILE="$CTI_HOME/logs/bridge.log"
+WORKSPACES_FILE="$CTI_HOME/workspaces.json"
 
 PASS=0
 FAIL=0
@@ -248,8 +249,8 @@ if [ "$CTI_RUNTIME" = "codex" ] || [ "$CTI_RUNTIME" = "auto" ]; then
   if [ -n "${CTI_CODEX_API_KEY:-}" ] || [ -n "${CODEX_API_KEY:-}" ] || [ -n "${OPENAI_API_KEY:-}" ]; then
     CODEX_AUTH=0
   elif command -v codex &>/dev/null; then
-    CODEX_AUTH_OUT=$(codex auth status 2>&1 || true)
-    if echo "$CODEX_AUTH_OUT" | grep -qiE 'logged.in|authenticated'; then
+    CODEX_AUTH_OUT=$(codex login status 2>&1 || codex auth status 2>&1 || true)
+    if echo "$CODEX_AUTH_OUT" | grep -qiE 'logged.in|authenticated|logged in'; then
       CODEX_AUTH=0
     fi
   fi
@@ -292,6 +293,63 @@ if [ -f "$CONFIG_FILE" ]; then
   else
     check "config.env permissions are 600 (currently $PERMS)" 1
   fi
+fi
+
+# --- workspace whitelist config ---
+if [ -f "$WORKSPACES_FILE" ]; then
+  if node - "$WORKSPACES_FILE" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const filePath = process.argv[2];
+const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+  throw new Error('must be a JSON object');
+}
+if (typeof raw.defaultAlias !== 'string' || raw.defaultAlias.trim() === '') {
+  throw new Error('defaultAlias is required');
+}
+if (!Array.isArray(raw.workspaces) || raw.workspaces.length === 0) {
+  throw new Error('workspaces must be a non-empty array');
+}
+const seen = new Set();
+let hasDefault = false;
+for (const workspace of raw.workspaces) {
+  if (!workspace || typeof workspace !== 'object') {
+    throw new Error('workspace entries must be objects');
+  }
+  const alias = typeof workspace.alias === 'string' ? workspace.alias.trim() : '';
+  const workspacePath = typeof workspace.path === 'string' ? workspace.path.trim() : '';
+  if (!alias) {
+    throw new Error('workspace alias cannot be empty');
+  }
+  if (!workspacePath) {
+    throw new Error(`workspace path cannot be empty for alias ${alias}`);
+  }
+  if (!path.isAbsolute(workspacePath)) {
+    throw new Error(`workspace path must be absolute for alias ${alias}`);
+  }
+  if (!fs.existsSync(workspacePath) || !fs.statSync(workspacePath).isDirectory()) {
+    throw new Error(`workspace path is invalid for alias ${alias}`);
+  }
+  if (seen.has(alias)) {
+    throw new Error(`duplicate alias ${alias}`);
+  }
+  if (alias === raw.defaultAlias) {
+    hasDefault = true;
+  }
+  seen.add(alias);
+}
+if (!hasDefault) {
+  throw new Error(`defaultAlias ${raw.defaultAlias} not found in workspaces`);
+}
+NODE
+  then
+    check "Workspace whitelist config valid ($WORKSPACES_FILE)" 0
+  else
+    check "Workspace whitelist config valid ($WORKSPACES_FILE)" 1
+  fi
+else
+  check "Workspace whitelist config (not set — using CTI_DEFAULT_WORKDIR only)" 0
 fi
 
 # --- Load config for channel checks ---

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -50,7 +50,7 @@ if [ ! -d "$TARGET_DIR/node_modules" ] || [ ! -d "$TARGET_DIR/node_modules/@open
 fi
 
 # Ensure build
-if [ ! -f "$TARGET_DIR/dist/daemon.mjs" ]; then
+if [ ! -f "$TARGET_DIR/dist/daemon.mjs" ] || [ ! -f "$TARGET_DIR/dist/weixin-login.mjs" ]; then
   echo "Building daemon bundle..."
   (cd "$TARGET_DIR" && npm run build)
 fi

--- a/src/__tests__/build-script.test.ts
+++ b/src/__tests__/build-script.test.ts
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const ROOT_DIR = path.resolve(import.meta.dirname, '..', '..');
+const DIST_DIR = path.join(ROOT_DIR, 'dist');
+const PACKAGE_JSON_PATH = path.join(ROOT_DIR, 'package.json');
+
+describe('build/install runtime artifacts', () => {
+  it('weixin login script points to a built runtime file', () => {
+    const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, 'utf-8'));
+    assert.equal(pkg.scripts['weixin:login'], 'node dist/weixin-login.mjs');
+  });
+
+  it('build emits the weixin login runtime bundle', () => {
+    fs.rmSync(path.join(DIST_DIR, 'weixin-login.mjs'), { force: true });
+
+    execFileSync('node', ['scripts/build.js'], {
+      cwd: ROOT_DIR,
+      stdio: 'pipe',
+    });
+
+    assert.equal(fs.existsSync(path.join(DIST_DIR, 'daemon.mjs')), true);
+    assert.equal(fs.existsSync(path.join(DIST_DIR, 'weixin-login.mjs')), true);
+  });
+});

--- a/src/__tests__/codex-provider.test.ts
+++ b/src/__tests__/codex-provider.test.ts
@@ -1,7 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
 import os from 'node:os';
 import path from 'node:path';
+import { PassThrough } from 'node:stream';
 
 // ── SSE utils tests ─────────────────────────────────────────
 
@@ -48,19 +50,52 @@ function parseSSEChunks(chunks: string[]): Array<{ type: string; data: string }>
     .map(line => JSON.parse(line.slice(6)));
 }
 
+function createMockCodexChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: PassThrough;
+    stderr: PassThrough;
+    stdin: PassThrough;
+    kill: (signal?: NodeJS.Signals) => boolean;
+    killedWith?: string;
+  };
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = new PassThrough();
+  child.kill = ((signal?: NodeJS.Signals) => {
+    child.killedWith = signal || 'SIGTERM';
+    queueMicrotask(() => child.emit('close', null, signal || 'SIGTERM'));
+    return true;
+  }) as (signal?: NodeJS.Signals) => boolean;
+  return child;
+}
+
+function emitCliEvents(
+  child: ReturnType<typeof createMockCodexChild>,
+  events: Array<Record<string, unknown>>,
+  closeCode = 0,
+): void {
+  queueMicrotask(() => {
+    for (const event of events) {
+      child.stdout.write(`${JSON.stringify(event)}\n`);
+    }
+    child.stdout.end();
+    child.stderr.end();
+    child.stdin.end();
+    child.emit('close', closeCode, null);
+  });
+}
+
 describe('CodexProvider', () => {
-  it('emits error when SDK init fails', async () => {
+  it('emits error when spawning the Codex CLI fails', async () => {
     const { CodexProvider } = await import('../codex-provider.js');
     const { PendingPermissions } = await import('../permission-gateway.js');
     const provider = new CodexProvider(new PendingPermissions());
 
-    // Force ensureSDK to fail by setting sdk to a broken module
-    (provider as any).sdk = { Codex: class { constructor() { throw new Error('Missing API key'); } } };
-    (provider as any).codex = null;
-    // Reset so ensureSDK re-runs the constructor
-    (provider as any).sdk = null;
-    // Override ensureSDK directly
-    (provider as any).ensureSDK = async () => { throw new Error('SDK init failed: Missing API key'); };
+    (provider as any).spawnCodexProcess = () => {
+      const child = createMockCodexChild();
+      queueMicrotask(() => child.emit('error', new Error('spawn codex ENOENT')));
+      return child;
+    };
 
     const stream = provider.streamChat({
       prompt: 'test',
@@ -72,7 +107,7 @@ describe('CodexProvider', () => {
 
     const errorEvent = events.find(e => e.type === 'error');
     assert.ok(errorEvent, 'Should emit an error event');
-    assert.ok(errorEvent!.data.includes('Missing API key'), 'Error should contain the cause');
+    assert.ok(errorEvent!.data.includes('ENOENT'), 'Error should contain the cause');
   });
 
   it('maps agent_message item to text SSE event', async () => {
@@ -512,7 +547,147 @@ describe('CodexProvider', () => {
       const events = parseSSEChunks(result.chunks);
       const errorEvent = events.find(e => e.type === 'error');
       assert.ok(errorEvent, 'Should emit an error event after the stream stalls');
-      assert.match(errorEvent.data, /stalled|timed out/i);
+      assert.match(errorEvent.data, /没有继续返回内容/);
+    } finally {
+      if (old === undefined) {
+        delete process.env.CTI_CODEX_STREAM_IDLE_TIMEOUT_MS;
+      } else {
+        process.env.CTI_CODEX_STREAM_IDLE_TIMEOUT_MS = old;
+      }
+    }
+  });
+});
+
+describe('CodexProvider CLI transport', () => {
+  it('ignores transient reconnect notices and still emits the final reply', async () => {
+    const { CodexProvider } = await import('../codex-provider.js');
+    const { PendingPermissions } = await import('../permission-gateway.js');
+    const provider = new CodexProvider(new PendingPermissions());
+
+    const child = createMockCodexChild();
+    let capturedArgs: string[] = [];
+    let promptFromStdin = '';
+    child.stdin.on('data', (chunk) => {
+      promptFromStdin += chunk.toString();
+    });
+
+    (provider as any).spawnCodexProcess = (args: string[]) => {
+      capturedArgs = args;
+      emitCliEvents(child, [
+        { type: 'thread.started', thread_id: 'cli-thread-1' },
+        { type: 'turn.started' },
+        { type: 'error', message: 'Reconnecting... 2/5 (timeout waiting for child process to exit)' },
+        { type: 'item.completed', item: { id: 'transport-1', type: 'error', message: 'Falling back from WebSockets to HTTPS transport. timeout waiting for child process to exit' } },
+        { type: 'item.completed', item: { id: 'msg-1', type: 'agent_message', text: '你好' } },
+        { type: 'turn.completed', usage: { input_tokens: 2, output_tokens: 1, cached_input_tokens: 0 } },
+      ]);
+      return child;
+    };
+
+    const stream = provider.streamChat({
+      prompt: '请只回复：你好',
+      sessionId: 'cli-session',
+      workingDirectory: '/tmp/demo-workdir',
+      permissionMode: 'acceptEdits',
+    });
+
+    const events = parseSSEChunks(await collectStream(stream));
+    const textEvent = events.find(e => e.type === 'text');
+    const errorEvents = events.filter(e => e.type === 'error');
+
+    assert.equal(promptFromStdin, '请只回复：你好');
+    assert.ok(capturedArgs.includes('exec'));
+    assert.ok(capturedArgs.includes('--json'));
+    assert.ok(capturedArgs.includes('/tmp/demo-workdir'));
+    assert.ok(capturedArgs.includes('sandbox_mode="workspace-write"'));
+    assert.ok(capturedArgs.includes('approval_policy="never"'));
+    assert.equal(textEvent?.data, '你好');
+    assert.equal(errorEvents.length, 0, 'Transient transport notices should not surface to users');
+  });
+
+  it('retries with a fresh CLI thread when resume session is invalid', async () => {
+    const { CodexProvider } = await import('../codex-provider.js');
+    const { PendingPermissions } = await import('../permission-gateway.js');
+    const provider = new CodexProvider(new PendingPermissions());
+
+    const first = createMockCodexChild();
+    const second = createMockCodexChild();
+    const capturedArgs: string[][] = [];
+    let callCount = 0;
+
+    (provider as any).spawnCodexProcess = (args: string[]) => {
+      capturedArgs.push(args);
+      callCount += 1;
+      if (callCount === 1) {
+        emitCliEvents(first, [
+          { type: 'error', message: 'No such session' },
+        ], 1);
+        return first;
+      }
+
+      emitCliEvents(second, [
+        { type: 'thread.started', thread_id: 'fresh-cli-thread' },
+        { type: 'item.completed', item: { id: 'msg-2', type: 'agent_message', text: 'fresh reply' } },
+        { type: 'turn.completed', usage: { input_tokens: 3, output_tokens: 2, cached_input_tokens: 0 } },
+      ]);
+      return second;
+    };
+
+    const stream = provider.streamChat({
+      prompt: 'retry please',
+      sessionId: 'cli-retry-session',
+      sdkSessionId: 'stale-thread-id',
+    });
+
+    const events = parseSSEChunks(await collectStream(stream));
+    const textEvent = events.find(e => e.type === 'text');
+    const errorEvent = events.find(e => e.type === 'error');
+
+    assert.equal(capturedArgs.length, 2, 'Should invoke Codex twice after resume failure');
+    assert.deepEqual(capturedArgs[0].slice(0, 2), ['exec', 'resume']);
+    assert.equal(capturedArgs[1][0], 'exec');
+    assert.notEqual(capturedArgs[1][1], 'resume');
+    assert.equal(textEvent?.data, 'fresh reply');
+    assert.equal(errorEvent, undefined);
+  });
+
+  it('fails fast when the CLI stops emitting output after thread.started', async () => {
+    const old = process.env.CTI_CODEX_STREAM_IDLE_TIMEOUT_MS;
+    process.env.CTI_CODEX_STREAM_IDLE_TIMEOUT_MS = '50';
+
+    try {
+      const { CodexProvider } = await import('../codex-provider.js');
+      const { PendingPermissions } = await import('../permission-gateway.js');
+      const provider = new CodexProvider(new PendingPermissions());
+
+      const child = createMockCodexChild();
+      (provider as any).spawnCodexProcess = () => {
+        queueMicrotask(() => {
+          child.stdout.write(`${JSON.stringify({ type: 'thread.started', thread_id: 'cli-stalled-thread' })}\n`);
+        });
+        return child;
+      };
+
+      const stream = provider.streamChat({
+        prompt: 'hello',
+        sessionId: 'cli-stalled-session',
+      });
+
+      const result = await Promise.race([
+        collectStream(stream).then((chunks) => ({ kind: 'chunks' as const, chunks })),
+        new Promise<{ kind: 'timeout' }>((resolve) => setTimeout(() => resolve({ kind: 'timeout' }), 250)),
+      ]);
+
+      assert.notEqual(result.kind, 'timeout', 'CLI stream should fail fast instead of hanging forever');
+      if (result.kind !== 'chunks') {
+        return;
+      }
+
+      const events = parseSSEChunks(result.chunks);
+      const errorEvent = events.find(e => e.type === 'error');
+      assert.ok(errorEvent);
+      assert.match(errorEvent.data, /没有继续返回内容/);
+      assert.equal(child.killedWith, 'SIGTERM');
     } finally {
       if (old === undefined) {
         delete process.env.CTI_CODEX_STREAM_IDLE_TIMEOUT_MS;
@@ -552,6 +727,16 @@ describe('buildCodexCliEnv', () => {
       fs.rmSync(tmpUserHome, { recursive: true, force: true });
       fs.rmSync(tmpCtiHome, { recursive: true, force: true });
     }
+  });
+});
+
+describe('toUserVisibleCodexErrorMessage', () => {
+  it('localizes stalled stream errors for end users', async () => {
+    const { toUserVisibleCodexErrorMessage } = await import('../codex-provider.js');
+    assert.equal(
+      toUserVisibleCodexErrorMessage('Codex stream stalled after thread.started for 45000ms'),
+      'Codex 已开始处理，但在 45 秒内没有继续返回内容。请稍后重试。',
+    );
   });
 });
 

--- a/src/__tests__/codex-provider.test.ts
+++ b/src/__tests__/codex-provider.test.ts
@@ -1,5 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
 
 // ── SSE utils tests ─────────────────────────────────────────
 
@@ -467,6 +469,89 @@ describe('CodexProvider', () => {
     assert.equal(startCalls, 1, 'Should fall back to a fresh thread');
     assert.ok(!errorEvent, 'Retry success should not emit error');
     assert.ok(resultEvent, 'Retry success should emit result');
+  });
+
+  it('fails fast when Codex stops emitting events after thread.started', async () => {
+    const old = process.env.CTI_CODEX_STREAM_IDLE_TIMEOUT_MS;
+    process.env.CTI_CODEX_STREAM_IDLE_TIMEOUT_MS = '50';
+
+    try {
+      const { CodexProvider } = await import('../codex-provider.js');
+      const { PendingPermissions } = await import('../permission-gateway.js');
+      const provider = new CodexProvider(new PendingPermissions());
+
+      const stalledThread = {
+        runStreamed: () => ({
+          events: (async function* () {
+            yield { type: 'thread.started', thread_id: 'stalled-thread-1' };
+            await new Promise(() => {});
+          })(),
+        }),
+      };
+
+      (provider as any).sdk = { Codex: class { constructor() {} } };
+      (provider as any).codex = {
+        startThread: () => stalledThread,
+      };
+
+      const stream = provider.streamChat({
+        prompt: 'hello',
+        sessionId: 'stalled-session',
+      });
+
+      const result = await Promise.race([
+        collectStream(stream).then((chunks) => ({ kind: 'chunks' as const, chunks })),
+        new Promise<{ kind: 'timeout' }>((resolve) => setTimeout(() => resolve({ kind: 'timeout' }), 250)),
+      ]);
+
+      assert.notEqual(result.kind, 'timeout', 'stream should fail fast instead of hanging forever');
+      if (result.kind !== 'chunks') {
+        return;
+      }
+
+      const events = parseSSEChunks(result.chunks);
+      const errorEvent = events.find(e => e.type === 'error');
+      assert.ok(errorEvent, 'Should emit an error event after the stream stalls');
+      assert.match(errorEvent.data, /stalled|timed out/i);
+    } finally {
+      if (old === undefined) {
+        delete process.env.CTI_CODEX_STREAM_IDLE_TIMEOUT_MS;
+      } else {
+        process.env.CTI_CODEX_STREAM_IDLE_TIMEOUT_MS = old;
+      }
+    }
+  });
+});
+
+describe('buildCodexCliEnv', () => {
+  it('isolates the bridge from the user Codex home and syncs login auth by default', async () => {
+    const tmpUserHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cti-user-home-'));
+    const tmpCtiHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cti-home-'));
+    const sharedCodexHome = path.join(tmpUserHome, '.codex');
+    fs.mkdirSync(sharedCodexHome, { recursive: true });
+    fs.writeFileSync(path.join(sharedCodexHome, 'auth.json'), '{"token":"shared-auth"}', 'utf-8');
+
+    try {
+      const { buildCodexCliEnv } = await import('../codex-provider.js');
+      const env = buildCodexCliEnv({
+        HOME: tmpUserHome,
+        PATH: '/usr/bin:/bin',
+        SHELL: '/bin/zsh',
+        LANG: 'en_US.UTF-8',
+        TMPDIR: '/tmp',
+        CODEX_THREAD_ID: 'should-not-leak',
+      }, { ctiHome: tmpCtiHome });
+
+      assert.equal(env.CODEX_THREAD_ID, undefined);
+      assert.equal(env.CODEX_HOME, path.join(tmpCtiHome, 'codex-home'));
+      assert.equal(
+        fs.readFileSync(path.join(tmpCtiHome, 'codex-home', 'auth.json'), 'utf-8'),
+        '{"token":"shared-auth"}',
+      );
+    } finally {
+      fs.rmSync(tmpUserHome, { recursive: true, force: true });
+      fs.rmSync(tmpCtiHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { maskSecret, configToSettings, type Config } from '../config.js';
+import { maskSecret, configToSettings, quoteEnvValue, type Config } from '../config.js';
 
 // ── maskSecret ──
 
@@ -21,6 +21,20 @@ describe('maskSecret', () => {
 
   it('handles exactly 5 chars', () => {
     assert.equal(maskSecret('12345'), '*2345');
+  });
+});
+
+describe('quoteEnvValue', () => {
+  it('keeps simple values unquoted', () => {
+    assert.equal(quoteEnvValue('/tmp/project'), '/tmp/project');
+    assert.equal(quoteEnvValue('codex'), 'codex');
+  });
+
+  it('quotes values with spaces for shell-safe config.env output', () => {
+    assert.equal(
+      quoteEnvValue('/Users/jitian/Documents/TiDB Cloud Zero'),
+      '"/Users/jitian/Documents/TiDB Cloud Zero"',
+    );
   });
 });
 

--- a/src/__tests__/weixin-adapter.test.ts
+++ b/src/__tests__/weixin-adapter.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import type { BridgeStore } from 'claude-to-im/src/lib/bridge/host.js';
 import { initBridgeContext } from 'claude-to-im/src/lib/bridge/context.js';
 import { WeixinAdapter } from '../adapters/weixin-adapter.js';
 import { MessageItemType } from '../adapters/weixin/weixin-types.js';
+import { CTI_HOME } from '../config.js';
+import { getWeixinActiveWorkspaceAlias } from '../weixin-store.js';
+import { WORKSPACES_CONFIG_PATH } from '../workspace-config.js';
 
 function createMockStore(settings: Record<string, string> = {}) {
   const auditLogs: Array<{ summary: string }> = [];
@@ -25,9 +30,19 @@ function setupContext(store: ReturnType<typeof createMockStore>) {
   });
 }
 
+class TestWeixinAdapter extends WeixinAdapter {
+  replies: string[] = [];
+
+  protected override async sendDirectTextReply(_accountId: string, _peerUserId: string, text: string): Promise<void> {
+    this.replies.push(text);
+  }
+}
+
 describe('weixin-adapter voice handling', () => {
   beforeEach(() => {
     setupContext(createMockStore({ bridge_weixin_media_enabled: 'false' }));
+    fs.rmSync(WORKSPACES_CONFIG_PATH, { force: true });
+    fs.rmSync(path.join(CTI_HOME, 'data', 'weixin-active-workspaces.json'), { force: true });
   });
 
   afterEach(() => {
@@ -76,5 +91,73 @@ describe('weixin-adapter voice handling', () => {
       (inbound?.raw as { userVisibleError?: string } | undefined)?.userVisibleError,
       'WeChat did not provide speech-to-text for this voice message. Please enable WeChat voice transcription and send it again.',
     );
+  });
+
+  it('uses the default workspace alias in inbound chat ids when whitelist is configured', async () => {
+    const workspaceDir = path.join(CTI_HOME, 'workspace-fixtures', 'zero');
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.writeFileSync(
+      WORKSPACES_CONFIG_PATH,
+      JSON.stringify({
+        defaultAlias: 'zero',
+        workspaces: [{ alias: 'zero', path: workspaceDir }],
+      }, null, 2),
+      'utf-8',
+    );
+
+    const adapter = new TestWeixinAdapter();
+
+    await (adapter as any).processMessage('acct-1', {
+      message_id: 'text-msg',
+      from_user_id: 'wx-user-3',
+      context_token: 'ctx-1',
+      item_list: [
+        {
+          type: MessageItemType.TEXT,
+          text_item: { text: 'hello workspace' },
+        },
+      ],
+    });
+
+    const inbound = await adapter.consumeOne();
+    assert.ok(inbound);
+    assert.equal(inbound?.address.chatId, 'weixin::acct-1::wx-user-3::zero');
+  });
+
+  it('handles switch workspace command without forwarding to the model', async () => {
+    const zeroDir = path.join(CTI_HOME, 'workspace-fixtures', 'zero');
+    const fooDir = path.join(CTI_HOME, 'workspace-fixtures', 'foo');
+    fs.mkdirSync(zeroDir, { recursive: true });
+    fs.mkdirSync(fooDir, { recursive: true });
+    fs.writeFileSync(
+      WORKSPACES_CONFIG_PATH,
+      JSON.stringify({
+        defaultAlias: 'zero',
+        workspaces: [
+          { alias: 'zero', path: zeroDir },
+          { alias: 'foo', path: fooDir },
+        ],
+      }, null, 2),
+      'utf-8',
+    );
+
+    const adapter = new TestWeixinAdapter();
+
+    await (adapter as any).processMessage('acct-1', {
+      message_id: 'switch-msg',
+      from_user_id: 'wx-user-4',
+      context_token: 'ctx-2',
+      item_list: [
+        {
+          type: MessageItemType.TEXT,
+          text_item: { text: '切换项目 foo' },
+        },
+      ],
+    });
+
+    const inbound = await adapter.consumeOne();
+    assert.equal(inbound, null);
+    assert.equal(getWeixinActiveWorkspaceAlias('acct-1', 'wx-user-4'), 'foo');
+    assert.match(adapter.replies[0] ?? '', /已切换到项目 foo/);
   });
 });

--- a/src/__tests__/weixin-command-router.test.ts
+++ b/src/__tests__/weixin-command-router.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseWeixinCommand } from '../weixin-command-router.js';
+
+describe('weixin-command-router', () => {
+  it('parses list command', () => {
+    assert.deepEqual(parseWeixinCommand('项目列表'), { type: 'list' });
+  });
+
+  it('parses current workspace command', () => {
+    assert.deepEqual(parseWeixinCommand('当前项目'), { type: 'current' });
+  });
+
+  it('parses switch workspace command', () => {
+    assert.deepEqual(parseWeixinCommand('切换项目 zero'), {
+      type: 'switch',
+      alias: 'zero',
+    });
+  });
+
+  it('returns null for non-command messages', () => {
+    assert.equal(parseWeixinCommand('帮我看看这个报错'), null);
+  });
+});

--- a/src/__tests__/weixin-login.test.ts
+++ b/src/__tests__/weixin-login.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildQrHtml } from '../weixin-login.js';
+import { buildQrHtml, isWeixinLoginCliEntry } from '../weixin-login.js';
 
 describe('weixin-login HTML', () => {
   it('embeds inline QR markup without remote CDN scripts', () => {
@@ -18,5 +18,32 @@ describe('weixin-login HTML', () => {
     assert.match(html, /<svg viewBox="0 0 10 10">/);
     assert.ok(!html.includes('cdn.jsdelivr.net'));
     assert.ok(!html.includes('<script'));
+  });
+
+  it('includes a real auto-refresh hint for expired QR codes', () => {
+    const html = buildQrHtml(
+      {
+        qrcode: 'qr-token',
+        qrImageUrl: 'weixin://qr-content',
+        status: 'waiting',
+        startedAt: Date.now(),
+        refreshCount: 0,
+      },
+      '<svg viewBox="0 0 10 10"><rect width="10" height="10" /></svg>',
+    );
+
+    assert.match(html, /http-equiv="refresh"/i);
+  });
+});
+
+describe('weixin-login CLI entry detection', () => {
+  it('treats symlinked entry paths as the same module', () => {
+    assert.equal(
+      isWeixinLoginCliEntry(
+        '/Users/jitian/.codex/skills/claude-to-im/dist/weixin-login.mjs',
+        'file:///Users/jitian/Documents/TiDB%20Cloud%20Zero/Claude-to-IM-skill-work/dist/weixin-login.mjs',
+      ),
+      true,
+    );
   });
 });

--- a/src/__tests__/weixin-store.test.ts
+++ b/src/__tests__/weixin-store.test.ts
@@ -6,9 +6,11 @@ import { CTI_HOME } from '../config.js';
 import {
   deleteWeixinAccount,
   getWeixinAccount,
+  getWeixinActiveWorkspaceAlias,
   getWeixinContextToken,
   listWeixinAccounts,
   setWeixinAccountEnabled,
+  setWeixinActiveWorkspaceAlias,
   upsertWeixinAccount,
   upsertWeixinContextToken,
 } from '../weixin-store.js';
@@ -16,12 +18,14 @@ import {
 const DATA_DIR = path.join(CTI_HOME, 'data');
 const ACCOUNTS_PATH = path.join(DATA_DIR, 'weixin-accounts.json');
 const TOKENS_PATH = path.join(DATA_DIR, 'weixin-context-tokens.json');
+const ACTIVE_WORKSPACES_PATH = path.join(DATA_DIR, 'weixin-active-workspaces.json');
 
 describe('weixin-store', () => {
   beforeEach(() => {
     fs.mkdirSync(DATA_DIR, { recursive: true });
     fs.rmSync(ACCOUNTS_PATH, { force: true });
     fs.rmSync(TOKENS_PATH, { force: true });
+    fs.rmSync(ACTIVE_WORKSPACES_PATH, { force: true });
   });
 
   it('upserts and lists accounts', () => {
@@ -147,5 +151,14 @@ describe('weixin-store', () => {
       'wx-bot-old::peer-a': 'ctx-old',
       'wx-bot-new::peer-b': 'ctx-new',
     });
+  });
+
+  it('stores active workspace alias per peer', () => {
+    setWeixinActiveWorkspaceAlias('wx-bot-1', 'peer-a', 'zero');
+    setWeixinActiveWorkspaceAlias('wx-bot-1', 'peer-b', 'foo');
+
+    assert.equal(getWeixinActiveWorkspaceAlias('wx-bot-1', 'peer-a'), 'zero');
+    assert.equal(getWeixinActiveWorkspaceAlias('wx-bot-1', 'peer-b'), 'foo');
+    assert.equal(getWeixinActiveWorkspaceAlias('wx-bot-1', 'peer-c'), undefined);
   });
 });

--- a/src/__tests__/workspace-config.test.ts
+++ b/src/__tests__/workspace-config.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { CTI_HOME } from '../config.js';
+import {
+  WORKSPACES_CONFIG_PATH,
+  loadWorkspaceConfig,
+} from '../workspace-config.js';
+
+describe('workspace-config', () => {
+  const fixturesDir = path.join(CTI_HOME, 'workspace-fixtures');
+
+  beforeEach(() => {
+    fs.rmSync(WORKSPACES_CONFIG_PATH, { force: true });
+    fs.rmSync(fixturesDir, { recursive: true, force: true });
+    fs.mkdirSync(fixturesDir, { recursive: true });
+  });
+
+  it('returns null when workspace config is missing', () => {
+    assert.equal(loadWorkspaceConfig(), null);
+  });
+
+  it('loads and normalizes a valid workspace config', () => {
+    const zeroDir = path.join(fixturesDir, 'zero');
+    fs.mkdirSync(zeroDir, { recursive: true });
+    fs.writeFileSync(
+      WORKSPACES_CONFIG_PATH,
+      JSON.stringify({
+        defaultAlias: 'zero',
+        workspaces: [
+          {
+            alias: 'zero',
+            path: `${zeroDir}/..//zero`,
+          },
+        ],
+      }, null, 2),
+      'utf-8',
+    );
+
+    const config = loadWorkspaceConfig();
+    assert.ok(config);
+    assert.equal(config.defaultAlias, 'zero');
+    assert.deepEqual(config.workspaces, [
+      {
+        alias: 'zero',
+        path: fs.realpathSync(zeroDir),
+      },
+    ]);
+  });
+
+  it('throws on duplicate aliases', () => {
+    const zeroDir = path.join(fixturesDir, 'zero');
+    const fooDir = path.join(fixturesDir, 'foo');
+    fs.mkdirSync(zeroDir, { recursive: true });
+    fs.mkdirSync(fooDir, { recursive: true });
+    fs.writeFileSync(
+      WORKSPACES_CONFIG_PATH,
+      JSON.stringify({
+        defaultAlias: 'zero',
+        workspaces: [
+          { alias: 'zero', path: zeroDir },
+          { alias: 'zero', path: fooDir },
+        ],
+      }, null, 2),
+      'utf-8',
+    );
+
+    assert.throws(() => loadWorkspaceConfig(), /Duplicate workspace alias: zero/);
+  });
+
+  it('throws when default alias does not exist', () => {
+    const zeroDir = path.join(fixturesDir, 'zero');
+    fs.mkdirSync(zeroDir, { recursive: true });
+    fs.writeFileSync(
+      WORKSPACES_CONFIG_PATH,
+      JSON.stringify({
+        defaultAlias: 'missing',
+        workspaces: [
+          { alias: 'zero', path: zeroDir },
+        ],
+      }, null, 2),
+      'utf-8',
+    );
+
+    assert.throws(() => loadWorkspaceConfig(), /Default workspace alias not found: missing/);
+  });
+});

--- a/src/adapters/weixin-adapter.ts
+++ b/src/adapters/weixin-adapter.ts
@@ -9,8 +9,10 @@ import { BaseChannelAdapter, registerAdapterFactory } from 'claude-to-im/src/lib
 import { getBridgeContext } from 'claude-to-im/src/lib/bridge/context.js';
 import {
   getWeixinAccount,
+  getWeixinActiveWorkspaceAlias,
   getWeixinContextToken,
   listWeixinAccounts,
+  setWeixinActiveWorkspaceAlias,
   upsertWeixinContextToken,
 } from '../weixin-store.js';
 import { getConfig, getUpdates, sendTextMessage, sendTyping } from './weixin/weixin-api.js';
@@ -29,6 +31,14 @@ import {
   MessageItemType,
   TypingStatus,
 } from './weixin/weixin-types.js';
+import { parseWeixinCommand } from '../weixin-command-router.js';
+import {
+  getDefaultWorkspace,
+  getWorkspaceByAlias,
+  loadWorkspaceConfig,
+  type WorkspaceConfig,
+  type WorkspaceEntry,
+} from '../workspace-config.js';
 
 const DEDUP_MAX = 500;
 const BACKOFF_BASE_MS = 2_000;
@@ -339,7 +349,16 @@ export class WeixinAdapter extends BaseChannelAdapter {
       text = text.trim() ? `${text}\n${failureNote}` : (attachments.length > 0 ? failureNote : text);
     }
 
-    const chatId = encodeWeixinChatId(accountId, message.from_user_id);
+    const trimmedText = text.trim();
+    if (attachments.length === 0 && trimmedText) {
+      const handled = await this.handleWorkspaceCommand(accountId, message.from_user_id, trimmedText);
+      if (handled) {
+        return;
+      }
+    }
+
+    const workspace = this.resolveWorkspaceSelection(accountId, message.from_user_id);
+    const chatId = encodeWeixinChatId(accountId, message.from_user_id, workspace?.alias);
     const inbound: InboundMessage = {
       messageId: message.message_id || `weixin_${accountId}_${message.seq || Date.now()}`,
       address: {
@@ -417,6 +436,152 @@ export class WeixinAdapter extends BaseChannelAdapter {
     }
 
     await sendTyping(creds, peerUserId, typingTicket, status);
+  }
+
+  protected async sendDirectTextReply(accountId: string, peerUserId: string, text: string): Promise<void> {
+    const account = getWeixinAccount(accountId);
+    if (!account) {
+      return;
+    }
+
+    const contextToken = getWeixinContextToken(accountId, peerUserId);
+    if (!contextToken) {
+      return;
+    }
+
+    await sendTextMessage(
+      this.accountToCreds(account),
+      peerUserId,
+      text,
+      contextToken,
+    );
+  }
+
+  private resolveWorkspaceSelection(accountId: string, peerUserId: string): WorkspaceEntry | undefined {
+    const config = this.loadWorkspaceConfigSafe();
+    if (!config) {
+      return undefined;
+    }
+
+    const activeAlias = getWeixinActiveWorkspaceAlias(accountId, peerUserId) || config.defaultAlias;
+    const workspace = getWorkspaceByAlias(config, activeAlias) || getDefaultWorkspace(config);
+    if (workspace.alias !== activeAlias) {
+      setWeixinActiveWorkspaceAlias(accountId, peerUserId, workspace.alias);
+    } else if (!getWeixinActiveWorkspaceAlias(accountId, peerUserId)) {
+      setWeixinActiveWorkspaceAlias(accountId, peerUserId, workspace.alias);
+    }
+    return workspace;
+  }
+
+  private loadWorkspaceConfigSafe(): WorkspaceConfig | null {
+    try {
+      return loadWorkspaceConfig();
+    } catch (err) {
+      console.warn(
+        '[weixin-adapter] Invalid workspace config:',
+        err instanceof Error ? err.message : err,
+      );
+      return null;
+    }
+  }
+
+  private async handleWorkspaceCommand(accountId: string, peerUserId: string, text: string): Promise<boolean> {
+    const command = parseWeixinCommand(text);
+    if (!command) {
+      return false;
+    }
+
+    const defaultWorkDir = getBridgeContext().store.getSetting('bridge_default_work_dir') || process.cwd();
+    let config: WorkspaceConfig | null = null;
+    try {
+      config = loadWorkspaceConfig();
+    } catch (err) {
+      await this.sendDirectTextReply(
+        accountId,
+        peerUserId,
+        `工作区配置有误：${err instanceof Error ? err.message : String(err)}`,
+      );
+      return true;
+    }
+
+    if (!config) {
+      const fallbackMessage = command.type === 'switch'
+        ? '尚未配置工作区白名单，暂不支持切换项目。请创建 ~/.claude-to-im/workspaces.json。'
+        : [
+            '当前未配置工作区白名单。',
+            `默认工作目录：${defaultWorkDir}`,
+            '如需多项目切换，请创建 ~/.claude-to-im/workspaces.json。',
+          ].join('\n');
+      await this.sendDirectTextReply(accountId, peerUserId, fallbackMessage);
+      return true;
+    }
+
+    const currentWorkspace = this.resolveWorkspaceSelection(accountId, peerUserId) || getDefaultWorkspace(config);
+    switch (command.type) {
+      case 'list': {
+        const lines = config.workspaces.map((workspace) => {
+          const tags: string[] = [];
+          if (workspace.alias === config.defaultAlias) {
+            tags.push('默认');
+          }
+          if (workspace.alias === currentWorkspace.alias) {
+            tags.push('当前');
+          }
+          const suffix = tags.length > 0 ? ` [${tags.join(' / ')}]` : '';
+          return `- ${workspace.alias}${suffix}\n  ${workspace.path}`;
+        });
+        await this.sendDirectTextReply(
+          accountId,
+          peerUserId,
+          `项目列表：\n${lines.join('\n')}`,
+        );
+        return true;
+      }
+      case 'current': {
+        await this.sendDirectTextReply(
+          accountId,
+          peerUserId,
+          `当前项目：${currentWorkspace.alias}\n${currentWorkspace.path}`,
+        );
+        return true;
+      }
+      case 'switch': {
+        const targetWorkspace = getWorkspaceByAlias(config, command.alias);
+        if (!targetWorkspace) {
+          const aliases = config.workspaces.map((workspace) => workspace.alias).join(', ');
+          await this.sendDirectTextReply(
+            accountId,
+            peerUserId,
+            `未找到项目 ${command.alias}。\n可用项目：${aliases}`,
+          );
+          return true;
+        }
+
+        setWeixinActiveWorkspaceAlias(accountId, peerUserId, targetWorkspace.alias);
+        await this.sendDirectTextReply(
+          accountId,
+          peerUserId,
+          `已切换到项目 ${targetWorkspace.alias}\n${targetWorkspace.path}`,
+        );
+        return true;
+      }
+      case 'help': {
+        await this.sendDirectTextReply(
+          accountId,
+          peerUserId,
+          [
+            '可用命令：',
+            '- 项目列表',
+            '- 当前项目',
+            '- 切换项目 <alias>',
+            '- 帮助',
+            '',
+            `当前项目：${currentWorkspace.alias}`,
+          ].join('\n'),
+        );
+        return true;
+      }
+    }
   }
 
   private accountToCreds(account: {

--- a/src/adapters/weixin/weixin-ids.ts
+++ b/src/adapters/weixin/weixin-ids.ts
@@ -1,19 +1,21 @@
 const WEIXIN_PREFIX = 'weixin::';
 const SEPARATOR = '::';
 
-export function encodeWeixinChatId(accountId: string, peerUserId: string): string {
+export function encodeWeixinChatId(accountId: string, peerUserId: string, workspaceAlias?: string): string {
+  if (workspaceAlias) {
+    return `${WEIXIN_PREFIX}${accountId}${SEPARATOR}${peerUserId}${SEPARATOR}${workspaceAlias}`;
+  }
   return `${WEIXIN_PREFIX}${accountId}${SEPARATOR}${peerUserId}`;
 }
 
-export function decodeWeixinChatId(chatId: string): { accountId: string; peerUserId: string } | null {
+export function decodeWeixinChatId(chatId: string): { accountId: string; peerUserId: string; workspaceAlias?: string } | null {
   if (!chatId.startsWith(WEIXIN_PREFIX)) return null;
   const rest = chatId.slice(WEIXIN_PREFIX.length);
-  const separatorIndex = rest.indexOf(SEPARATOR);
-  if (separatorIndex < 0) return null;
+  const parts = rest.split(SEPARATOR);
+  if (parts.length < 2 || parts.length > 3) return null;
 
-  const accountId = rest.slice(0, separatorIndex);
-  const peerUserId = rest.slice(separatorIndex + SEPARATOR.length);
+  const [accountId, peerUserId, workspaceAlias] = parts;
   if (!accountId || !peerUserId) return null;
 
-  return { accountId, peerUserId };
+  return { accountId, peerUserId, workspaceAlias };
 }

--- a/src/codex-provider.ts
+++ b/src/codex-provider.ts
@@ -1,18 +1,13 @@
 /**
- * Codex Provider — LLMProvider implementation backed by @openai/codex-sdk.
- *
- * Maps Codex SDK thread events to the SSE stream format consumed by
- * the bridge conversation engine, making Codex a drop-in alternative
- * to the Claude Code SDK backend.
- *
- * Requires `@openai/codex-sdk` to be installed (optionalDependency).
- * The provider lazily imports the SDK at first use and throws a clear
- * error if it is not available.
+ * Codex Provider — LLMProvider implementation backed by the Codex CLI JSONL
+ * stream. We keep the old SDK-backed path only for injected test doubles.
  */
 
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { createInterface } from 'node:readline';
 
 import type { LLMProvider, StreamChatParams } from 'claude-to-im/src/lib/bridge/host.js';
 import { CTI_HOME } from './config.js';
@@ -28,9 +23,11 @@ const MIME_EXT: Record<string, string> = {
   'image/webp': '.webp',
 };
 
-const DEFAULT_CODEX_STREAM_IDLE_TIMEOUT_MS = 45_000;
+const DEFAULT_CODEX_STREAM_IDLE_TIMEOUT_MS = 120_000;
 const SHARED_CODEX_HOME_NAME = '.codex';
 const BRIDGE_CODEX_HOME_NAME = 'codex-home';
+const DEFAULT_CODEX_EXECUTABLE = 'codex';
+const CLI_WATCHDOG_INTERVAL_MS = 1_000;
 const FORWARDED_CODEX_ENV_KEYS = [
   'HOME',
   'PATH',
@@ -101,6 +98,20 @@ function shouldSkipGitRepoCheck(): boolean {
 
 function shouldUseSharedCodexHome(env: NodeJS.ProcessEnv = process.env): boolean {
   return env.CTI_CODEX_USE_SHARED_HOME === 'true';
+}
+
+export function toUserVisibleCodexErrorMessage(message: string): string {
+  const stalled = message.match(/^Codex stream stalled after (.+) for (\d+)ms$/i);
+  if (stalled) {
+    const [, context, timeoutMs] = stalled;
+    const seconds = Math.max(1, Math.round(Number(timeoutMs) / 1000));
+    if (context === 'thread.started') {
+      return `Codex 已开始处理，但在 ${seconds} 秒内没有继续返回内容。请稍后重试。`;
+    }
+    return `Codex 在 ${context} 之后卡住了，${seconds} 秒内没有继续返回内容。请稍后重试。`;
+  }
+
+  return message;
 }
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
@@ -195,14 +206,95 @@ function shouldRetryFreshThread(message: string): boolean {
   );
 }
 
+function resolveCodexExecutable(env: NodeJS.ProcessEnv = process.env): string {
+  return env.CTI_CODEX_EXECUTABLE || DEFAULT_CODEX_EXECUTABLE;
+}
+
+function getCliWatchdogIntervalMs(timeoutMs: number): number {
+  return Math.max(10, Math.min(CLI_WATCHDOG_INTERVAL_MS, Math.floor(timeoutMs / 2) || 10));
+}
+
+function toSandboxMode(permissionMode?: string): 'workspace-write' | 'read-only' {
+  return permissionMode === 'acceptEdits' ? 'workspace-write' : 'read-only';
+}
+
+export function buildCodexExecArgs(
+  params: Pick<StreamChatParams, 'permissionMode' | 'workingDirectory' | 'model'>,
+  options: {
+    resumeThreadId?: string;
+    imagePaths?: string[];
+  } = {},
+): string[] {
+  const args: string[] = ['exec'];
+
+  if (options.resumeThreadId) {
+    args.push('resume');
+  }
+
+  args.push('--json');
+  args.push('-c', `approval_policy=${JSON.stringify('never')}`);
+  args.push('-c', `sandbox_mode=${JSON.stringify(toSandboxMode(params.permissionMode))}`);
+
+  if (shouldSkipGitRepoCheck()) {
+    args.push('--skip-git-repo-check');
+  }
+
+  if (params.workingDirectory) {
+    args.push('-C', params.workingDirectory);
+  }
+
+  if (shouldPassModelToCodex() && params.model) {
+    args.push('-m', params.model);
+  }
+
+  for (const imagePath of options.imagePaths ?? []) {
+    args.push('-i', imagePath);
+  }
+
+  if (options.resumeThreadId) {
+    args.push(options.resumeThreadId);
+  }
+  args.push('-');
+
+  return args;
+}
+
+function isTransientCodexCliMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.startsWith('reconnecting...') ||
+    lower.includes('falling back from websockets to https transport') ||
+    lower.includes('falling back to http')
+  );
+}
+
+function isCodexCliStatusItem(item: Record<string, unknown>): boolean {
+  return item.type === 'error' && typeof item.message === 'string' && isTransientCodexCliMessage(item.message);
+}
+
 export class CodexProvider implements LLMProvider {
   private sdk: CodexModule | null = null;
   private codex: CodexInstance | null = null;
+  private loggedCliEnv = false;
 
   /** Maps session IDs to Codex thread IDs for resume. */
   private threadIds = new Map<string, string>();
 
   constructor(private pendingPerms: PendingPermissions) {}
+
+  private spawnCodexProcess(
+    args: string[],
+    options: {
+      cwd?: string;
+      env: Record<string, string>;
+    },
+  ): ChildProcessWithoutNullStreams {
+    return spawn(resolveCodexExecutable(), args, {
+      cwd: options.cwd || process.cwd(),
+      env: options.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  }
 
   /**
    * Lazily load the Codex SDK. Throws a clear error if not installed.
@@ -289,178 +381,406 @@ export class CodexProvider implements LLMProvider {
     }
   }
 
-  streamChat(params: StreamChatParams): ReadableStream<string> {
-    const self = this;
+  private async streamChatViaCli(
+    controller: ReadableStreamDefaultController<string>,
+    params: StreamChatParams,
+    imagePaths: string[],
+  ): Promise<void> {
+    const cliEnv = buildCodexCliEnv();
+    if (cliEnv.CODEX_HOME && !this.loggedCliEnv) {
+      console.log(`[codex-provider] Using isolated Codex home: ${cliEnv.CODEX_HOME}`);
+      this.loggedCliEnv = true;
+    }
 
+    let savedThreadId = this.threadIds.get(params.sessionId) || params.sdkSessionId || undefined;
+    let retriedFresh = false;
+
+    while (true) {
+      const args = buildCodexExecArgs(params, {
+        resumeThreadId: savedThreadId,
+        imagePaths,
+      });
+      const child = this.spawnCodexProcess(args, {
+        cwd: params.workingDirectory || process.cwd(),
+        env: cliEnv,
+      });
+
+      const outcome = await new Promise<{
+        kind: 'success' | 'abort' | 'retry-fresh' | 'error';
+        error?: Error;
+      }>((resolve) => {
+        const timeoutMs = getCodexStreamIdleTimeoutMs();
+        let stdoutLines: ReturnType<typeof createInterface> | null = null;
+        let settled = false;
+        let lastActivityAt = Date.now();
+        let lastContext = savedThreadId ? 'resume start' : 'turn start';
+        let sawMeaningfulEvent = false;
+        let sawResult = false;
+        let pendingErrorMessage = '';
+        let stalledError: Error | null = null;
+        let stderrBuf = '';
+        let aborted = false;
+
+        const settle = (next: { kind: 'success' | 'abort' | 'retry-fresh' | 'error'; error?: Error }) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          clearInterval(watchdog);
+          params.abortController?.signal.removeEventListener('abort', onAbort);
+          stdoutLines?.close();
+          resolve(next);
+        };
+
+        const touch = (context?: string) => {
+          lastActivityAt = Date.now();
+          if (context) {
+            lastContext = context;
+          }
+        };
+
+        const onAbort = () => {
+          aborted = true;
+          child.kill('SIGTERM');
+        };
+
+        const watchdog = setInterval(() => {
+          if (Date.now() - lastActivityAt <= timeoutMs) {
+            return;
+          }
+          stalledError = new Error(`Codex stream stalled after ${lastContext} for ${timeoutMs}ms`);
+          child.kill('SIGTERM');
+          setTimeout(() => child.kill('SIGKILL'), 1_000).unref();
+        }, getCliWatchdogIntervalMs(timeoutMs));
+
+        if (params.abortController?.signal.aborted) {
+          onAbort();
+        } else {
+          params.abortController?.signal.addEventListener('abort', onAbort, { once: true });
+        }
+
+        stdoutLines = createInterface({ input: child.stdout });
+        stdoutLines.on('line', (line) => {
+          touch(lastContext);
+
+          let event: Record<string, unknown>;
+          try {
+            event = JSON.parse(line) as Record<string, unknown>;
+          } catch {
+            return;
+          }
+
+          const type = String(event.type || 'unknown event');
+          lastContext = type;
+
+          switch (type) {
+            case 'thread.started': {
+              const threadId = event.thread_id as string | undefined;
+              if (threadId) {
+                this.threadIds.set(params.sessionId, threadId);
+                controller.enqueue(sseEvent('status', { session_id: threadId }));
+              }
+              sawMeaningfulEvent = true;
+              break;
+            }
+
+            case 'turn.started':
+              sawMeaningfulEvent = true;
+              break;
+
+            case 'item.completed': {
+              const item = event.item as Record<string, unknown> | undefined;
+              if (!item) {
+                break;
+              }
+              if (isCodexCliStatusItem(item)) {
+                console.warn('[codex-provider] CLI transport status:', item.message);
+                break;
+              }
+              if (item.type === 'error') {
+                pendingErrorMessage = String(item.message || 'Thread error');
+                break;
+              }
+              sawMeaningfulEvent = true;
+              this.handleCompletedItem(controller, item);
+              break;
+            }
+
+            case 'turn.completed': {
+              sawMeaningfulEvent = true;
+              sawResult = true;
+              const usage = event.usage as Record<string, unknown> | undefined;
+              const threadId = this.threadIds.get(params.sessionId);
+
+              controller.enqueue(sseEvent('result', {
+                usage: usage ? {
+                  input_tokens: usage.input_tokens ?? 0,
+                  output_tokens: usage.output_tokens ?? 0,
+                  cache_read_input_tokens: usage.cached_input_tokens ?? 0,
+                } : undefined,
+                ...(threadId ? { session_id: threadId } : {}),
+              }));
+              break;
+            }
+
+            case 'turn.failed':
+              pendingErrorMessage = String((event as { message?: string }).message || 'Turn failed');
+              break;
+
+            case 'error': {
+              const message = String((event as { message?: string }).message || 'Thread error');
+              if (isTransientCodexCliMessage(message)) {
+                console.warn('[codex-provider] CLI transport status:', message);
+                break;
+              }
+              pendingErrorMessage = message;
+              break;
+            }
+
+            default:
+              break;
+          }
+        });
+
+        child.stderr.on('data', (chunk) => {
+          touch(lastContext);
+          stderrBuf += chunk.toString();
+          if (stderrBuf.length > 4096) {
+            stderrBuf = stderrBuf.slice(-4096);
+          }
+        });
+
+        child.on('error', (err) => {
+          settle({ kind: 'error', error: err });
+        });
+
+        child.on('close', (code, signal) => {
+          if (aborted || signal === 'SIGTERM' || signal === 'SIGKILL') {
+            if (stalledError) {
+              settle({ kind: 'error', error: stalledError });
+              return;
+            }
+            settle({ kind: 'abort' });
+            return;
+          }
+
+          if (savedThreadId && !retriedFresh && !sawMeaningfulEvent && shouldRetryFreshThread(pendingErrorMessage || stderrBuf)) {
+            console.warn('[codex-provider] Resume failed, retrying with a fresh thread:', pendingErrorMessage || stderrBuf);
+            settle({ kind: 'retry-fresh' });
+            return;
+          }
+
+          if (!sawResult && pendingErrorMessage) {
+            settle({ kind: 'error', error: new Error(pendingErrorMessage) });
+            return;
+          }
+
+          if ((code ?? 0) !== 0) {
+            const suffix = stderrBuf.trim() ? `: ${stderrBuf.trim()}` : '';
+            settle({ kind: 'error', error: new Error(`Codex CLI exited with code ${code}${suffix}`) });
+            return;
+          }
+
+          settle({ kind: 'success' });
+        });
+
+        child.stdin.write(params.prompt);
+        child.stdin.end();
+      });
+
+      if (outcome.kind === 'retry-fresh') {
+        savedThreadId = undefined;
+        retriedFresh = true;
+        continue;
+      }
+
+      if (outcome.kind === 'abort') {
+        return;
+      }
+
+      if (outcome.kind === 'error') {
+        throw outcome.error;
+      }
+
+      return;
+    }
+  }
+
+  private async streamChatViaInjectedSdk(
+    controller: ReadableStreamDefaultController<string>,
+    params: StreamChatParams,
+    input: string | Array<Record<string, string>>,
+  ): Promise<void> {
+    const { codex } = await this.ensureSDK();
+
+    const inMemoryThreadId = this.threadIds.get(params.sessionId);
+    let savedThreadId = inMemoryThreadId || params.sdkSessionId || undefined;
+    const approvalPolicy = toApprovalPolicy(params.permissionMode);
+    const passModel = shouldPassModelToCodex();
+
+    const threadOptions: Record<string, unknown> = {
+      ...(passModel && params.model ? { model: params.model } : {}),
+      ...(params.workingDirectory ? { workingDirectory: params.workingDirectory } : {}),
+      ...(shouldSkipGitRepoCheck() ? { skipGitRepoCheck: true } : {}),
+      approvalPolicy,
+    };
+
+    let retryFresh = false;
+
+    while (true) {
+      let thread: ThreadInstance;
+      if (savedThreadId) {
+        try {
+          thread = codex.resumeThread(savedThreadId, threadOptions);
+        } catch {
+          thread = codex.startThread(threadOptions);
+        }
+      } else {
+        thread = codex.startThread(threadOptions);
+      }
+
+      let sawAnyEvent = false;
+      let lastEventType = 'turn start';
+      try {
+        const { events } = await thread.runStreamed(input);
+        const iterator = events[Symbol.asyncIterator]();
+
+        while (true) {
+          let nextEvent: IteratorResult<Record<string, unknown>>;
+          try {
+            nextEvent = await this.readNextEvent(
+              iterator,
+              getCodexStreamIdleTimeoutMs(),
+              params.abortController?.signal,
+              sawAnyEvent ? lastEventType : 'turn start',
+            );
+          } catch (err) {
+            if (err instanceof CodexStreamAbortedError) {
+              break;
+            }
+            const iteratorReturn = iterator.return;
+            if (iteratorReturn) {
+              try {
+                void iteratorReturn.call(iterator);
+              } catch {
+                // Ignore iterator teardown failures
+              }
+            }
+            throw err;
+          }
+
+          if (nextEvent.done) {
+            break;
+          }
+
+          const event = nextEvent.value;
+          sawAnyEvent = true;
+          lastEventType = String(event.type || 'unknown event');
+
+          switch (event.type) {
+            case 'thread.started': {
+              const threadId = event.thread_id as string;
+              this.threadIds.set(params.sessionId, threadId);
+
+              controller.enqueue(sseEvent('status', {
+                session_id: threadId,
+              }));
+              break;
+            }
+
+            case 'item.completed': {
+              const item = event.item as Record<string, unknown>;
+              this.handleCompletedItem(controller, item);
+              break;
+            }
+
+            case 'turn.completed': {
+              const usage = event.usage as Record<string, unknown> | undefined;
+              const threadId = this.threadIds.get(params.sessionId);
+
+              controller.enqueue(sseEvent('result', {
+                usage: usage ? {
+                  input_tokens: usage.input_tokens ?? 0,
+                  output_tokens: usage.output_tokens ?? 0,
+                  cache_read_input_tokens: usage.cached_input_tokens ?? 0,
+                } : undefined,
+                ...(threadId ? { session_id: threadId } : {}),
+              }));
+              break;
+            }
+
+            case 'turn.failed': {
+              const error = (event as { message?: string }).message;
+              controller.enqueue(sseEvent('error', error || 'Turn failed'));
+              break;
+            }
+
+            case 'error': {
+              const error = (event as { message?: string }).message;
+              controller.enqueue(sseEvent('error', error || 'Thread error'));
+              break;
+            }
+
+            default:
+              break;
+          }
+        }
+        return;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (savedThreadId && !retryFresh && !sawAnyEvent && shouldRetryFreshThread(message)) {
+          console.warn('[codex-provider] Resume failed, retrying with a fresh thread:', message);
+          savedThreadId = undefined;
+          retryFresh = true;
+          continue;
+        }
+        throw err;
+      }
+    }
+  }
+
+  streamChat(params: StreamChatParams): ReadableStream<string> {
     return new ReadableStream<string>({
-      start(controller) {
+      start: (controller) => {
         (async () => {
           const tempFiles: string[] = [];
           try {
-            const { codex } = await self.ensureSDK();
-
-            // Resolve or create thread
-            const inMemoryThreadId = self.threadIds.get(params.sessionId);
-            let savedThreadId = inMemoryThreadId || params.sdkSessionId || undefined;
-
-            const approvalPolicy = toApprovalPolicy(params.permissionMode);
-            const passModel = shouldPassModelToCodex();
-
-            const threadOptions: Record<string, unknown> = {
-              ...(passModel && params.model ? { model: params.model } : {}),
-              ...(params.workingDirectory ? { workingDirectory: params.workingDirectory } : {}),
-              ...(shouldSkipGitRepoCheck() ? { skipGitRepoCheck: true } : {}),
-              approvalPolicy,
-            };
-
-            // Build input: Codex SDK UserInput supports { type: "text" } and
-            // { type: "local_image", path: string }. We write base64 data to
-            // temp files so the SDK can read them as local images.
             const imageFiles = params.files?.filter(
               f => f.type.startsWith('image/')
             ) ?? [];
 
-            let input: string | Array<Record<string, string>>;
-            if (imageFiles.length > 0) {
-              const parts: Array<Record<string, string>> = [
-                { type: 'text', text: params.prompt },
-              ];
-              for (const file of imageFiles) {
-                const ext = MIME_EXT[file.type] || '.png';
-                const tmpPath = path.join(os.tmpdir(), `cti-img-${Date.now()}-${Math.random().toString(36).slice(2)}${ext}`);
-                fs.writeFileSync(tmpPath, Buffer.from(file.data, 'base64'));
-                tempFiles.push(tmpPath);
-                parts.push({ type: 'local_image', path: tmpPath });
-              }
-              input = parts;
-            } else {
-              input = params.prompt;
+            let sdkInput: string | Array<Record<string, string>> = params.prompt;
+            for (const file of imageFiles) {
+              const ext = MIME_EXT[file.type] || '.png';
+              const tmpPath = path.join(os.tmpdir(), `cti-img-${Date.now()}-${Math.random().toString(36).slice(2)}${ext}`);
+              fs.writeFileSync(tmpPath, Buffer.from(file.data, 'base64'));
+              tempFiles.push(tmpPath);
             }
 
-            let retryFresh = false;
-
-            while (true) {
-              let thread: ThreadInstance;
-              if (savedThreadId) {
-                try {
-                  thread = codex.resumeThread(savedThreadId, threadOptions);
-                } catch {
-                  thread = codex.startThread(threadOptions);
-                }
-              } else {
-                thread = codex.startThread(threadOptions);
+            if (this.codex) {
+              if (tempFiles.length > 0) {
+                sdkInput = [
+                  { type: 'text', text: params.prompt },
+                  ...tempFiles.map((tmpPath) => ({ type: 'local_image', path: tmpPath })),
+                ];
               }
-
-              let sawAnyEvent = false;
-              let lastEventType = 'turn start';
-              try {
-                const { events } = await thread.runStreamed(input);
-                const iterator = events[Symbol.asyncIterator]();
-
-                while (true) {
-                  let nextEvent: IteratorResult<Record<string, unknown>>;
-                  try {
-                    nextEvent = await self.readNextEvent(
-                      iterator,
-                      getCodexStreamIdleTimeoutMs(),
-                      params.abortController?.signal,
-                      sawAnyEvent ? lastEventType : 'turn start',
-                    );
-                  } catch (err) {
-                    if (err instanceof CodexStreamAbortedError) {
-                      break;
-                    }
-                    const iteratorReturn = iterator.return;
-                    if (iteratorReturn) {
-                      try {
-                        void iteratorReturn.call(iterator);
-                      } catch {
-                        // Ignore iterator teardown failures
-                      }
-                    }
-                    throw err;
-                  }
-
-                  if (nextEvent.done) {
-                    break;
-                  }
-
-                  const event = nextEvent.value;
-                  sawAnyEvent = true;
-                  lastEventType = String(event.type || 'unknown event');
-
-                  switch (event.type) {
-                    case 'thread.started': {
-                      const threadId = event.thread_id as string;
-                      self.threadIds.set(params.sessionId, threadId);
-
-                      controller.enqueue(sseEvent('status', {
-                        session_id: threadId,
-                      }));
-                      break;
-                    }
-
-                    case 'item.completed': {
-                      const item = event.item as Record<string, unknown>;
-                      self.handleCompletedItem(controller, item);
-                      break;
-                    }
-
-                    case 'turn.completed': {
-                      const usage = event.usage as Record<string, unknown> | undefined;
-                      const threadId = self.threadIds.get(params.sessionId);
-
-                      controller.enqueue(sseEvent('result', {
-                        usage: usage ? {
-                          input_tokens: usage.input_tokens ?? 0,
-                          output_tokens: usage.output_tokens ?? 0,
-                          cache_read_input_tokens: usage.cached_input_tokens ?? 0,
-                        } : undefined,
-                        ...(threadId ? { session_id: threadId } : {}),
-                      }));
-                      break;
-                    }
-
-                    case 'turn.failed': {
-                      const error = (event as { message?: string }).message;
-                      controller.enqueue(sseEvent('error', error || 'Turn failed'));
-                      break;
-                    }
-
-                    case 'error': {
-                      const error = (event as { message?: string }).message;
-                      controller.enqueue(sseEvent('error', error || 'Thread error'));
-                      break;
-                    }
-
-                    // item.started, item.updated, turn.started — no action needed
-                  }
-                }
-                break;
-              } catch (err) {
-                const message = err instanceof Error ? err.message : String(err);
-                if (savedThreadId && !retryFresh && !sawAnyEvent && shouldRetryFreshThread(message)) {
-                  console.warn('[codex-provider] Resume failed, retrying with a fresh thread:', message);
-                  savedThreadId = undefined;
-                  retryFresh = true;
-                  continue;
-                }
-                throw err;
-              }
+              await this.streamChatViaInjectedSdk(controller, params, sdkInput);
+            } else {
+              await this.streamChatViaCli(controller, params, tempFiles);
             }
 
             controller.close();
           } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
+            const rawMessage = err instanceof Error ? err.message : String(err);
+            const userVisibleMessage = toUserVisibleCodexErrorMessage(rawMessage);
             console.error('[codex-provider] Error:', err instanceof Error ? err.stack || err.message : err);
             try {
-              controller.enqueue(sseEvent('error', message));
+              controller.enqueue(sseEvent('error', userVisibleMessage));
               controller.close();
             } catch {
               // Controller already closed
             }
           } finally {
-            // Clean up temp image files
             for (const tmp of tempFiles) {
               try { fs.unlinkSync(tmp); } catch { /* ignore */ }
             }

--- a/src/codex-provider.ts
+++ b/src/codex-provider.ts
@@ -15,6 +15,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import type { LLMProvider, StreamChatParams } from 'claude-to-im/src/lib/bridge/host.js';
+import { CTI_HOME } from './config.js';
 import type { PendingPermissions } from './permission-gateway.js';
 import { sseEvent } from './sse-utils.js';
 
@@ -27,6 +28,37 @@ const MIME_EXT: Record<string, string> = {
   'image/webp': '.webp',
 };
 
+const DEFAULT_CODEX_STREAM_IDLE_TIMEOUT_MS = 45_000;
+const SHARED_CODEX_HOME_NAME = '.codex';
+const BRIDGE_CODEX_HOME_NAME = 'codex-home';
+const FORWARDED_CODEX_ENV_KEYS = [
+  'HOME',
+  'PATH',
+  'SHELL',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TMPDIR',
+  'USER',
+  'LOGNAME',
+  'TERM',
+  'TERMINFO',
+  'TERM_PROGRAM',
+  'TERM_PROGRAM_VERSION',
+  'COLORTERM',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'ALL_PROXY',
+  'NO_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'all_proxy',
+  'no_proxy',
+  'SSL_CERT_FILE',
+  'SSL_CERT_DIR',
+  'NODE_EXTRA_CA_CERTS',
+] as const;
+
 // All SDK types kept as `any` because @openai/codex-sdk is optional.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CodexModule = any;
@@ -34,6 +66,13 @@ type CodexModule = any;
 type CodexInstance = any;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ThreadInstance = any;
+
+class CodexStreamAbortedError extends Error {
+  constructor() {
+    super('Codex stream aborted');
+    this.name = 'CodexStreamAbortedError';
+  }
+}
 
 /**
  * Map bridge permission modes to Codex approval policies.
@@ -58,6 +97,93 @@ function shouldPassModelToCodex(): boolean {
 /** Allow Codex to run outside a trusted Git repository when explicitly enabled. */
 function shouldSkipGitRepoCheck(): boolean {
   return process.env.CTI_CODEX_SKIP_GIT_REPO_CHECK === 'true';
+}
+
+function shouldUseSharedCodexHome(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.CTI_CODEX_USE_SHARED_HOME === 'true';
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.floor(parsed);
+}
+
+export function getCodexStreamIdleTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  return parsePositiveInt(env.CTI_CODEX_STREAM_IDLE_TIMEOUT_MS, DEFAULT_CODEX_STREAM_IDLE_TIMEOUT_MS);
+}
+
+function ensureDirectory(dirPath: string, mode: number): void {
+  fs.mkdirSync(dirPath, { recursive: true, mode });
+  try {
+    fs.chmodSync(dirPath, mode);
+  } catch {
+    // Ignore chmod failures on filesystems that do not support it
+  }
+}
+
+function syncFileIfPresent(sourcePath: string, targetPath: string, mode: number): void {
+  if (!fs.existsSync(sourcePath)) {
+    return;
+  }
+  fs.copyFileSync(sourcePath, targetPath);
+  try {
+    fs.chmodSync(targetPath, mode);
+  } catch {
+    // Ignore chmod failures on filesystems that do not support it
+  }
+}
+
+export function prepareBridgeCodexHome(
+  env: NodeJS.ProcessEnv = process.env,
+  options: { ctiHome?: string } = {},
+): string {
+  const userHome = env.HOME || os.homedir();
+  const ctiHome = options.ctiHome || CTI_HOME;
+  const bridgeCodexHome = path.join(ctiHome, BRIDGE_CODEX_HOME_NAME);
+  const sharedCodexHome = path.join(userHome, SHARED_CODEX_HOME_NAME);
+
+  ensureDirectory(bridgeCodexHome, 0o700);
+  syncFileIfPresent(
+    path.join(sharedCodexHome, 'auth.json'),
+    path.join(bridgeCodexHome, 'auth.json'),
+    0o600,
+  );
+
+  return bridgeCodexHome;
+}
+
+export function buildCodexCliEnv(
+  baseEnv: NodeJS.ProcessEnv = process.env,
+  options: { ctiHome?: string } = {},
+): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  for (const key of FORWARDED_CODEX_ENV_KEYS) {
+    const value = baseEnv[key];
+    if (value) {
+      env[key] = value;
+    }
+  }
+
+  if (!env.HOME) {
+    env.HOME = baseEnv.HOME || os.homedir();
+  }
+
+  if (shouldUseSharedCodexHome(baseEnv)) {
+    if (baseEnv.CODEX_HOME) {
+      env.CODEX_HOME = baseEnv.CODEX_HOME;
+    }
+    return env;
+  }
+
+  env.CODEX_HOME = prepareBridgeCodexHome({ ...baseEnv, HOME: env.HOME }, options);
+  return env;
 }
 
 function shouldRetryFreshThread(message: string): boolean {
@@ -101,14 +227,66 @@ export class CodexProvider implements LLMProvider {
       || process.env.OPENAI_API_KEY
       || undefined;
     const baseUrl = process.env.CTI_CODEX_BASE_URL || undefined;
+    const cliEnv = buildCodexCliEnv();
 
     const CodexClass = this.sdk.Codex;
     this.codex = new CodexClass({
       ...(apiKey ? { apiKey } : {}),
       ...(baseUrl ? { baseUrl } : {}),
+      env: cliEnv,
     });
 
+    if (cliEnv.CODEX_HOME) {
+      console.log(`[codex-provider] Using isolated Codex home: ${cliEnv.CODEX_HOME}`);
+    }
+
     return { sdk: this.sdk, codex: this.codex };
+  }
+
+  private async readNextEvent(
+    iterator: AsyncIterator<Record<string, unknown>>,
+    timeoutMs: number,
+    signal?: AbortSignal,
+    context?: string,
+  ): Promise<IteratorResult<Record<string, unknown>>> {
+    let timeoutId: NodeJS.Timeout | undefined;
+    let abortHandler: (() => void) | undefined;
+
+    const nextPromise = iterator.next();
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        const message = context
+          ? `Codex stream stalled after ${context} for ${timeoutMs}ms`
+          : `Codex stream stalled for ${timeoutMs}ms`;
+        reject(new Error(message));
+      }, timeoutMs);
+    });
+
+    const abortPromise = signal
+      ? new Promise<never>((_, reject) => {
+        if (signal.aborted) {
+          reject(new CodexStreamAbortedError());
+          return;
+        }
+        abortHandler = () => reject(new CodexStreamAbortedError());
+        signal.addEventListener('abort', abortHandler, { once: true });
+      })
+      : undefined;
+
+    try {
+      const waiters: Array<Promise<IteratorResult<Record<string, unknown>> | never>> = [nextPromise, timeoutPromise];
+      if (abortPromise) {
+        waiters.push(abortPromise);
+      }
+      return await Promise.race(waiters);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      if (signal && abortHandler) {
+        signal.removeEventListener('abort', abortHandler);
+      }
+    }
   }
 
   streamChat(params: StreamChatParams): ReadableStream<string> {
@@ -174,14 +352,42 @@ export class CodexProvider implements LLMProvider {
               }
 
               let sawAnyEvent = false;
+              let lastEventType = 'turn start';
               try {
                 const { events } = await thread.runStreamed(input);
+                const iterator = events[Symbol.asyncIterator]();
 
-                for await (const event of events) {
-                  sawAnyEvent = true;
-                  if (params.abortController?.signal.aborted) {
+                while (true) {
+                  let nextEvent: IteratorResult<Record<string, unknown>>;
+                  try {
+                    nextEvent = await self.readNextEvent(
+                      iterator,
+                      getCodexStreamIdleTimeoutMs(),
+                      params.abortController?.signal,
+                      sawAnyEvent ? lastEventType : 'turn start',
+                    );
+                  } catch (err) {
+                    if (err instanceof CodexStreamAbortedError) {
+                      break;
+                    }
+                    const iteratorReturn = iterator.return;
+                    if (iteratorReturn) {
+                      try {
+                        void iteratorReturn.call(iterator);
+                      } catch {
+                        // Ignore iterator teardown failures
+                      }
+                    }
+                    throw err;
+                  }
+
+                  if (nextEvent.done) {
                     break;
                   }
+
+                  const event = nextEvent.value;
+                  sawAnyEvent = true;
+                  lastEventType = String(event.type || 'unknown event');
 
                   switch (event.type) {
                     case 'thread.started': {

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,9 +117,16 @@ export function loadConfig(): Config {
   };
 }
 
+export function quoteEnvValue(value: string): string {
+  if (/^[A-Za-z0-9_./:@,+-]+$/.test(value)) {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
 function formatEnvLine(key: string, value: string | undefined): string {
   if (value === undefined || value === "") return "";
-  return `${key}=${value}\n`;
+  return `${key}=${quoteEnvValue(value)}\n`;
 }
 
 export function saveConfig(config: Config): void {

--- a/src/weixin-command-router.ts
+++ b/src/weixin-command-router.ts
@@ -1,0 +1,32 @@
+export type WeixinCommand =
+  | { type: 'list' }
+  | { type: 'current' }
+  | { type: 'switch'; alias: string }
+  | { type: 'help' };
+
+export function parseWeixinCommand(text: string): WeixinCommand | null {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed === '项目列表') {
+    return { type: 'list' };
+  }
+  if (trimmed === '当前项目') {
+    return { type: 'current' };
+  }
+  if (trimmed === '帮助') {
+    return { type: 'help' };
+  }
+
+  const switchMatch = trimmed.match(/^切换项目\s+([A-Za-z0-9._-]+)$/);
+  if (switchMatch) {
+    return {
+      type: 'switch',
+      alias: switchMatch[1]!,
+    };
+  }
+
+  return null;
+}

--- a/src/weixin-login.ts
+++ b/src/weixin-login.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import QRCode from 'qrcode';
 import { CTI_HOME, loadConfig } from './config.js';
 import { startLoginQr, pollLoginQrStatus } from './adapters/weixin/weixin-api.js';
@@ -41,6 +42,7 @@ export function buildQrHtml(session: LoginSession, qrSvg: string): string {
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="refresh" content="5" />
     <title>Claude-to-IM WeChat Login</title>
     <style>
       :root { color-scheme: light; }
@@ -105,7 +107,7 @@ export function buildQrHtml(session: LoginSession, qrSvg: string): string {
       <div class="card">
         <h1>微信扫码登录 Claude-to-IM</h1>
         <p>请用手机微信扫描下面的二维码，并在手机上确认登录授权。</p>
-        <p class="muted">如果二维码过期，CLI 会自动刷新这个页面内容；如果浏览器没有更新，请手动刷新一次。</p>
+        <p class="muted">页面会每 5 秒自动刷新一次；如果二维码过期，CLI 重写 HTML 后浏览器会自动看到最新二维码。</p>
         <div class="qr">
           <div id="qrcode">${qrSvg}</div>
         </div>
@@ -187,6 +189,19 @@ async function refreshSession(previous: LoginSession, baseUrl?: string): Promise
   return next;
 }
 
+export function isWeixinLoginCliEntry(entryPath?: string, importUrl: string = import.meta.url): boolean {
+  if (!entryPath) {
+    return false;
+  }
+
+  const modulePath = fileURLToPath(importUrl);
+  try {
+    return fs.realpathSync(entryPath) === fs.realpathSync(modulePath);
+  } catch {
+    return path.resolve(entryPath) === path.resolve(modulePath);
+  }
+}
+
 export async function runWeixinLogin(): Promise<{ accountId: string; htmlPath: string }> {
   ensureRuntimeDir();
   const config = loadConfig();
@@ -261,10 +276,7 @@ export async function runWeixinLogin(): Promise<{ accountId: string; htmlPath: s
   }
 }
 
-const isMainModule = (() => {
-  const entry = process.argv[1];
-  return !!entry && path.resolve(entry) === path.resolve(new URL(import.meta.url).pathname);
-})();
+const isMainModule = isWeixinLoginCliEntry(process.argv[1], import.meta.url);
 
 if (isMainModule) {
   runWeixinLogin().catch((err) => {

--- a/src/weixin-store.ts
+++ b/src/weixin-store.ts
@@ -20,6 +20,7 @@ const DATA_DIR = path.join(CTI_HOME, 'data');
 // current Weixin bridge intentionally runs in single-account mode.
 const ACCOUNTS_PATH = path.join(DATA_DIR, 'weixin-accounts.json');
 const CONTEXT_TOKENS_PATH = path.join(DATA_DIR, 'weixin-context-tokens.json');
+const ACTIVE_WORKSPACES_PATH = path.join(DATA_DIR, 'weixin-active-workspaces.json');
 const DEFAULT_BASE_URL = 'https://ilinkai.weixin.qq.com';
 const DEFAULT_CDN_BASE_URL = 'https://novac2c.cdn.weixin.qq.com/c2c';
 
@@ -121,6 +122,16 @@ function readContextTokens(): Record<string, string> {
 function writeContextTokens(tokens: Record<string, string>): void {
   ensureDir(DATA_DIR);
   atomicWrite(CONTEXT_TOKENS_PATH, JSON.stringify(tokens, null, 2));
+}
+
+function readActiveWorkspaceAliases(): Record<string, string> {
+  ensureDir(DATA_DIR);
+  return readJson<Record<string, string>>(ACTIVE_WORKSPACES_PATH, {});
+}
+
+function writeActiveWorkspaceAliases(aliases: Record<string, string>): void {
+  ensureDir(DATA_DIR);
+  atomicWrite(ACTIVE_WORKSPACES_PATH, JSON.stringify(aliases, null, 2));
 }
 
 function contextKey(accountId: string, peerUserId: string): string {
@@ -228,6 +239,26 @@ export function deleteWeixinContextTokensByAccount(accountId: string): void {
     Object.entries(tokens).filter(([key]) => !key.startsWith(`${accountId}::`)),
   );
   writeContextTokens(nextTokens);
+  deleteWeixinActiveWorkspacesByAccount(accountId);
+}
+
+export function getWeixinActiveWorkspaceAlias(accountId: string, peerUserId: string): string | undefined {
+  const aliases = readActiveWorkspaceAliases();
+  return aliases[contextKey(accountId, peerUserId)];
+}
+
+export function setWeixinActiveWorkspaceAlias(accountId: string, peerUserId: string, alias: string): void {
+  const aliases = readActiveWorkspaceAliases();
+  aliases[contextKey(accountId, peerUserId)] = alias;
+  writeActiveWorkspaceAliases(aliases);
+}
+
+export function deleteWeixinActiveWorkspacesByAccount(accountId: string): void {
+  const aliases = readActiveWorkspaceAliases();
+  const nextAliases = Object.fromEntries(
+    Object.entries(aliases).filter(([key]) => !key.startsWith(`${accountId}::`)),
+  );
+  writeActiveWorkspaceAliases(nextAliases);
 }
 
 export function getWeixinAccountsFilePath(): string {

--- a/src/workspace-config.ts
+++ b/src/workspace-config.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { CTI_HOME } from './config.js';
+
+export interface WorkspaceEntry {
+  alias: string;
+  path: string;
+}
+
+export interface WorkspaceConfig {
+  defaultAlias: string;
+  workspaces: WorkspaceEntry[];
+}
+
+export const WORKSPACES_CONFIG_PATH = path.join(CTI_HOME, 'workspaces.json');
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+}
+
+function isWorkspaceRecord(value: unknown): value is { alias?: unknown; path?: unknown } {
+  return typeof value === 'object' && value !== null;
+}
+
+export function loadWorkspaceConfig(): WorkspaceConfig | null {
+  if (!fs.existsSync(WORKSPACES_CONFIG_PATH)) {
+    return null;
+  }
+
+  const raw = readJson(WORKSPACES_CONFIG_PATH);
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('Workspace config must be a JSON object');
+  }
+
+  const defaultAlias = typeof (raw as { defaultAlias?: unknown }).defaultAlias === 'string'
+    ? (raw as { defaultAlias: string }).defaultAlias.trim()
+    : '';
+  const workspacesValue = (raw as { workspaces?: unknown }).workspaces;
+
+  if (!defaultAlias) {
+    throw new Error('Workspace config is missing defaultAlias');
+  }
+  if (!Array.isArray(workspacesValue) || workspacesValue.length === 0) {
+    throw new Error('Workspace config must contain at least one workspace');
+  }
+
+  const seenAliases = new Set<string>();
+  const workspaces = workspacesValue.map((item) => {
+    if (!isWorkspaceRecord(item)) {
+      throw new Error('Each workspace must be an object');
+    }
+
+    const alias = typeof item.alias === 'string' ? item.alias.trim() : '';
+    const workspacePath = typeof item.path === 'string' ? item.path.trim() : '';
+
+    if (!alias) {
+      throw new Error('Workspace alias cannot be empty');
+    }
+    if (!workspacePath) {
+      throw new Error(`Workspace path cannot be empty for alias: ${alias}`);
+    }
+    if (seenAliases.has(alias)) {
+      throw new Error(`Duplicate workspace alias: ${alias}`);
+    }
+    if (!path.isAbsolute(workspacePath)) {
+      throw new Error(`Workspace path must be absolute for alias: ${alias}`);
+    }
+    if (!fs.existsSync(workspacePath)) {
+      throw new Error(`Workspace path does not exist for alias: ${alias}`);
+    }
+
+    const stats = fs.statSync(workspacePath);
+    if (!stats.isDirectory()) {
+      throw new Error(`Workspace path is not a directory for alias: ${alias}`);
+    }
+
+    seenAliases.add(alias);
+    return {
+      alias,
+      path: fs.realpathSync(workspacePath),
+    };
+  });
+
+  if (!workspaces.some((workspace) => workspace.alias === defaultAlias)) {
+    throw new Error(`Default workspace alias not found: ${defaultAlias}`);
+  }
+
+  return {
+    defaultAlias,
+    workspaces,
+  };
+}
+
+export function getWorkspaceByAlias(config: WorkspaceConfig, alias: string): WorkspaceEntry | undefined {
+  return config.workspaces.find((workspace) => workspace.alias === alias);
+}
+
+export function getDefaultWorkspace(config: WorkspaceConfig): WorkspaceEntry {
+  const workspace = getWorkspaceByAlias(config, config.defaultAlias);
+  if (!workspace) {
+    throw new Error(`Default workspace alias not found: ${config.defaultAlias}`);
+  }
+  return workspace;
+}


### PR DESCRIPTION
## Summary
- add WeChat workspace whitelist loading plus in-chat control commands (`项目列表` / `当前项目` / `切换项目 <alias>`)
- persist active workspace per WeChat peer and keep workspace-specific chat ids isolated
- fix production/symlink WeChat login flow, add real QR auto-refresh, and tighten doctor/install checks
- isolate the bridge Codex runtime from interactive `~/.codex` MCP config, sync login auth into a bridge-specific `CODEX_HOME`, and fail stalled streams with a clear error instead of hanging silently

## Verification
- `npm test`
- `npm run build`
- `bash ~/.codex/skills/claude-to-im/scripts/doctor.sh`
- live provider check: confirmed isolated Codex home is used and stalled turns now surface an explicit SSE error instead of hanging forever

## Notes
- the new Codex guard intentionally turns silent stalls into explicit failures; it does not claim to fix every upstream Codex CLI reconnect issue
- `CTI_CODEX_USE_SHARED_HOME=true` remains available as an escape hatch for users who explicitly want the bridge to inherit their main Codex config and MCP servers
