### PR TITLE
fix: add settingSources to query options so CLI loads user plugins

### DIFF
--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -467,6 +467,7 @@ export class SDKLLMProvider implements LLMProvider {
               resume: params.sdkSessionId || undefined,
               abortController: params.abortController,
               permissionMode: (params.permissionMode as 'default' | 'acceptEdits' | 'plan') || undefined,
+              settingSources: ['user'],
               includePartialMessages: true,
               env: cleanEnv,
               stderr: (data: string) => {


### PR DESCRIPTION
## Summary

- When `settingSources` is not passed to the SDK `query()` function, it defaults to `[]` via `settingSources ?? []` inside the SDK internals
- This causes the CLI to receive `--setting-sources ""`, which means **no user settings are loaded** — including `enabledPlugins` in the user's `settings.json`
- As a result, plugins installed by the user (e.g. `superpowers`, `code-review`) are invisible to bridge-spawned Claude sessions — only built-in skills (`simplify`, `loop`, `claude-api`) appear in the IM conversation

## Fix

Add `settingSources: ['user']` to the `queryOptions` object in `src/llm-provider.ts`, so the CLI subprocess loads user-level settings (which contain the `enabledPlugins` map).

## Root cause trace

```
bridge queryOptions (no settingSources)
  → SDK query(): settingSources = undefined → ?? [] → []
    → CLI args: --setting-sources ""
      → CLI loads NO settings → enabledPlugins ignored
        → plugins (superpowers, code-review, etc.) not loaded
```

## Test plan

- [ ] Install a plugin (e.g. `superpowers`) via Claude Code settings
- [ ] Start the bridge and send a message via IM
- [ ] Verify the system-reminder in the IM session lists all plugin skills, not just built-in ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)