### PR TITLE
fix: prevent SDK fallback to built-in cli.js and suppress benign exit code 1

### DIFF
--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -508,8 +508,13 @@ export class SDKLLMProvider implements LLMProvider {
                   };
                 },
             };
-            if (cliPath) {
-              queryOptions.pathToClaudeCodeExecutable = cliPath;
+            // Prefer explicit env var to avoid SDK falling back to built-in official cli.js
+            // when resolveClaudeCliPath() occasionally returns undefined (e.g. --help timeout).
+            const resolvedCliPath = process.env.CTI_CLAUDE_CODE_EXECUTABLE || cliPath;
+            if (resolvedCliPath) {
+              queryOptions.pathToClaudeCodeExecutable = resolvedCliPath;
+            } else {
+              console.warn('[llm-provider] WARNING: pathToClaudeCodeExecutable is not set, SDK may fallback to built-in official cli.js!');
             }
 
             const prompt = buildPrompt(params.prompt, params.files);
@@ -531,6 +536,16 @@ export class SDKLLMProvider implements LLMProvider {
             }
 
             const isTransportExit = message.includes('process exited with code');
+
+            // ── Case 0: Benign exit code 1 with no stderr ──
+            // claude-internal often exits with code 1 after a successful response.
+            // When there is no meaningful stderr, this is normal teardown — suppress it.
+            const isCode1WithNoStderr = message.includes('process exited with code 1') && !stderrBuf.trim();
+            if (isCode1WithNoStderr) {
+              console.log('[llm-provider] Suppressing exit code 1 with no stderr — likely normal claude-internal exit');
+              controller.close();
+              return;
+            }
 
             // ── Case 1: Result already received ──
             // The SDK delivered a proper result (success or structured error).


### PR DESCRIPTION
## Problem

When using a custom CLI (e.g. `claude-internal` via `CTI_CLAUDE_CODE_EXECUTABLE`), the SDK intermittently falls back to its built-in official `cli.js`, causing authentication failures and empty `Error:` messages in IM.

### Root Cause

`resolveClaudeCliPath()` can occasionally return `undefined` when `claude-internal --help` times out under system load. When `pathToClaudeCodeExecutable` is not passed to the SDK, it silently uses its bundled `cli.js` (official Claude), which fails with the custom auth tokens.

Additionally, `claude-internal` often exits with code 1 after a successful response, triggering spurious error handling.

## Fix

1. **CLI path priority**: Prefer `CTI_CLAUDE_CODE_EXECUTABLE` env var over `resolveClaudeCliPath()` result, ensuring the custom CLI is always used even when path resolution fails
2. **Exit code 1 suppression**: When `process exited with code 1` occurs with no stderr output, treat it as normal teardown instead of an error

## Changes

- `src/llm-provider.ts`: 2 targeted fixes (17 lines added, 2 removed)