### PR TITLE
Pass Codex abort signal and document SSH/git settings

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -37,6 +37,22 @@ CTI_DEFAULT_MODE=code
 # Priority: CTI_CODEX_API_KEY > CODEX_API_KEY > OPENAI_API_KEY
 # CTI_CODEX_API_KEY=
 # CTI_CODEX_BASE_URL=
+# Sandbox for Codex turns:
+#   read-only          — safest, no writes
+#   workspace-write    — allow writes inside the working directory
+#   danger-full-access — unrestricted local access (use with care)
+# Defaults by mode: code -> workspace-write, plan/ask -> read-only
+# CTI_CODEX_SANDBOX_MODE=workspace-write
+# Enable network for Codex turns.
+# Required for SSH, git fetch/pull/push, and live web access.
+# CTI_CODEX_NETWORK_ENABLED=true
+# Extra directories that Codex may access in addition to the working directory.
+# Useful for SSH keys and git config, for example:
+# CTI_CODEX_ADDITIONAL_DIRECTORIES=$HOME/.ssh,$HOME/.config/git
+# CTI_CODEX_ADDITIONAL_DIRECTORIES=
+# Abort a single Codex turn if it stays blocked too long (milliseconds).
+# Example: 30 minutes
+# CTI_CODEX_TURN_TIMEOUT_MS=1800000
 # Allow Codex to run when CTI_DEFAULT_WORKDIR is not inside a trusted Git repo.
 # Keep this off unless you intentionally want Codex to work in arbitrary folders.
 # CTI_CODEX_SKIP_GIT_REPO_CHECK=true
@@ -88,5 +104,7 @@ CTI_TG_CHAT_ID=your-chat-id
 # Useful for channels that lack interactive permission UI (e.g. Feishu
 # WebSocket long-connection mode, where there is no HTTP webhook to
 # render clickable approve/deny buttons).
+# Feishu / QQ / WeChat can also approve prompts by replying `1`, `2`, `3`
+# or `/perm allow|allow_session|deny <id>`.
 # ⚠️  Only enable this in trusted, access-controlled environments.
 # CTI_AUTO_APPROVE=true

--- a/references/troubleshooting.md
+++ b/references/troubleshooting.md
@@ -30,6 +30,30 @@
 5. For Feishu: confirm the app has been approved and event subscriptions are configured
 6. Check logs for incoming message events: `/claude-to-im logs 200`
 
+## Session looks stuck
+
+**Symptoms**: One task starts, but later messages in the same chat get no useful reply or appear to hang forever.
+
+**Steps**:
+
+1. Send `/stop` in the same chat to interrupt the current session task
+2. If you want a clean thread, send `/new`
+3. Check whether the bridge is repeatedly waiting on one long Codex turn: `/claude-to-im logs 200`
+4. Optionally set a turn timeout in `config.env`:
+   ```bash
+   CTI_CODEX_TURN_TIMEOUT_MS=1800000
+   ```
+5. Restart the bridge after config changes:
+   ```bash
+   /claude-to-im stop
+   /claude-to-im start
+   ```
+
+**Notes**:
+
+- Newer bridge builds return an explicit "task still running" message instead of silently queueing later chat messages.
+- If the task is truly stuck, the bridge can auto-stop it after the idle window set by `CTI_ACTIVE_TASK_STALE_MS` (default 15 minutes).
+
 ## Permission timeout
 
 **Symptoms**: Claude Code session starts but times out waiting for tool approval.
@@ -39,6 +63,53 @@
 1. The bridge runs Claude Code in non-interactive mode; ensure your Claude Code configuration allows the necessary tools
 2. Consider using `--allowedTools` in your configuration to pre-approve common tools
 3. Check network connectivity if the timeout occurs during API calls
+
+For Feishu / QQ / WeChat, permission replies are text-based:
+
+- Reply `1` to allow once
+- Reply `2` to allow the session
+- Reply `3` to deny
+- Or use `/perm allow|allow_session|deny <id>`
+
+If you want fully automatic approvals in a trusted environment, set:
+
+```bash
+CTI_AUTO_APPROVE=true
+```
+
+## Codex cannot SSH or use git
+
+**Symptoms**: Codex from Feishu / WeChat can edit local files, but `ssh`, `git fetch/pull/push`, or git operations involving credentials keep failing.
+
+**Steps**:
+
+1. Enable Codex network access in `config.env`:
+   ```bash
+   CTI_CODEX_NETWORK_ENABLED=true
+   ```
+2. Give Codex the right sandbox level:
+   ```bash
+   CTI_CODEX_SANDBOX_MODE=workspace-write
+   ```
+   If your workflow depends on `~/.ssh`, `~/.gitconfig`, or other home-directory credentials, you may need:
+   ```bash
+   CTI_CODEX_SANDBOX_MODE=danger-full-access
+   ```
+3. If you want to keep `workspace-write`, explicitly grant the extra directories Codex needs:
+   ```bash
+   CTI_CODEX_ADDITIONAL_DIRECTORIES=$HOME/.ssh,$HOME/.config/git
+   ```
+4. Prefer SSH keys or a preconfigured git credential helper. Interactive password prompts are fragile in bridge-driven sessions.
+5. Restart the bridge after config changes:
+   ```bash
+   /claude-to-im stop
+   /claude-to-im start
+   ```
+
+**Notes**:
+
+- `git add` / `git commit` may still trigger a permission request unless you approve it in chat or enable `CTI_AUTO_APPROVE=true`.
+- Network-enabled Codex is a security tradeoff. Only use it in chats you control.
 
 ## High memory usage
 

--- a/src/__tests__/codex-provider.test.ts
+++ b/src/__tests__/codex-provider.test.ts
@@ -419,6 +419,126 @@ describe('CodexProvider', () => {
     }
   });
 
+  it('passes abort signal to runStreamed so /stop can interrupt Codex turns', async () => {
+    const { CodexProvider } = await import('../codex-provider.js');
+    const { PendingPermissions } = await import('../permission-gateway.js');
+    const provider = new CodexProvider(new PendingPermissions());
+
+    let capturedTurnOptions: Record<string, unknown> | undefined;
+    const mockThread = {
+      runStreamed: (_input: unknown, turnOptions?: Record<string, unknown>) => {
+        capturedTurnOptions = turnOptions;
+        return {
+          events: (async function* () {
+            yield { type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 1, cached_input_tokens: 0 } };
+          })(),
+        };
+      },
+    };
+    (provider as any).sdk = { Codex: class { constructor() {} } };
+    (provider as any).codex = {
+      startThread: () => mockThread,
+    };
+
+    const abortController = new AbortController();
+    const stream = provider.streamChat({
+      prompt: 'stop me',
+      sessionId: 'abortable-session',
+      abortController,
+    });
+    await collectStream(stream);
+
+    assert.equal(capturedTurnOptions?.signal, abortController.signal);
+  });
+
+  it('derives sandbox, network, and additional directories from config env', async () => {
+    const oldSandbox = process.env.CTI_CODEX_SANDBOX_MODE;
+    const oldNetwork = process.env.CTI_CODEX_NETWORK_ENABLED;
+    const oldDirs = process.env.CTI_CODEX_ADDITIONAL_DIRECTORIES;
+    process.env.CTI_CODEX_SANDBOX_MODE = 'danger-full-access';
+    process.env.CTI_CODEX_NETWORK_ENABLED = 'true';
+    process.env.CTI_CODEX_ADDITIONAL_DIRECTORIES = '/tmp/one,/tmp/two';
+
+    try {
+      const { CodexProvider } = await import('../codex-provider.js');
+      const { PendingPermissions } = await import('../permission-gateway.js');
+      const provider = new CodexProvider(new PendingPermissions());
+
+      let capturedStartOptions: Record<string, unknown> | undefined;
+      const mockThread = {
+        runStreamed: () => ({
+          events: (async function* () {
+            yield { type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 1, cached_input_tokens: 0 } };
+          })(),
+        }),
+      };
+      (provider as any).sdk = { Codex: class { constructor() {} } };
+      (provider as any).codex = {
+        startThread: (opts: Record<string, unknown>) => {
+          capturedStartOptions = opts;
+          return mockThread;
+        },
+      };
+
+      const stream = provider.streamChat({
+        prompt: 'hello',
+        sessionId: 'sandbox-session',
+        permissionMode: 'acceptEdits',
+      });
+      await collectStream(stream);
+
+      assert.equal(capturedStartOptions?.sandboxMode, 'danger-full-access');
+      assert.equal(capturedStartOptions?.networkAccessEnabled, true);
+      assert.deepEqual(capturedStartOptions?.additionalDirectories, ['/tmp/one', '/tmp/two']);
+    } finally {
+      if (oldSandbox === undefined) delete process.env.CTI_CODEX_SANDBOX_MODE;
+      else process.env.CTI_CODEX_SANDBOX_MODE = oldSandbox;
+      if (oldNetwork === undefined) delete process.env.CTI_CODEX_NETWORK_ENABLED;
+      else process.env.CTI_CODEX_NETWORK_ENABLED = oldNetwork;
+      if (oldDirs === undefined) delete process.env.CTI_CODEX_ADDITIONAL_DIRECTORIES;
+      else process.env.CTI_CODEX_ADDITIONAL_DIRECTORIES = oldDirs;
+    }
+  });
+
+  it('defaults code mode to workspace-write sandbox when unset', async () => {
+    const oldSandbox = process.env.CTI_CODEX_SANDBOX_MODE;
+    delete process.env.CTI_CODEX_SANDBOX_MODE;
+    try {
+      const { CodexProvider } = await import('../codex-provider.js');
+      const { PendingPermissions } = await import('../permission-gateway.js');
+      const provider = new CodexProvider(new PendingPermissions());
+
+      let capturedStartOptions: Record<string, unknown> | undefined;
+      const mockThread = {
+        runStreamed: () => ({
+          events: (async function* () {
+            yield { type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 1, cached_input_tokens: 0 } };
+          })(),
+        }),
+      };
+      (provider as any).sdk = { Codex: class { constructor() {} } };
+      (provider as any).codex = {
+        startThread: (opts: Record<string, unknown>) => {
+          capturedStartOptions = opts;
+          return mockThread;
+        },
+      };
+
+      const stream = provider.streamChat({
+        prompt: 'hello',
+        sessionId: 'default-sandbox-session',
+        permissionMode: 'acceptEdits',
+      });
+      await collectStream(stream);
+
+      assert.equal(capturedStartOptions?.sandboxMode, 'workspace-write');
+    } finally {
+      if (oldSandbox !== undefined) {
+        process.env.CTI_CODEX_SANDBOX_MODE = oldSandbox;
+      }
+    }
+  });
+
   it('retries with fresh thread when resume fails before any events', async () => {
     const { CodexProvider } = await import('../codex-provider.js');
     const { PendingPermissions } = await import('../permission-gateway.js');

--- a/src/codex-provider.ts
+++ b/src/codex-provider.ts
@@ -35,6 +35,8 @@ type CodexInstance = any;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ThreadInstance = any;
 
+type CodexSandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
+
 /**
  * Map bridge permission modes to Codex approval policies.
  * - 'acceptEdits' (code mode) → 'on-failure' (auto-approve most things)
@@ -58,6 +60,70 @@ function shouldPassModelToCodex(): boolean {
 /** Allow Codex to run outside a trusted Git repository when explicitly enabled. */
 function shouldSkipGitRepoCheck(): boolean {
   return process.env.CTI_CODEX_SKIP_GIT_REPO_CHECK === 'true';
+}
+
+function parseBooleanEnv(name: string): boolean | undefined {
+  const raw = process.env[name];
+  if (raw === undefined) return undefined;
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  return undefined;
+}
+
+function getSandboxMode(permissionMode?: string): CodexSandboxMode {
+  const raw = process.env.CTI_CODEX_SANDBOX_MODE;
+  if (raw === 'read-only' || raw === 'workspace-write' || raw === 'danger-full-access') {
+    return raw;
+  }
+
+  switch (permissionMode) {
+    case 'acceptEdits':
+      return 'workspace-write';
+    case 'plan':
+    case 'default':
+    default:
+      return 'read-only';
+  }
+}
+
+function getAdditionalDirectories(): string[] | undefined {
+  const raw = process.env.CTI_CODEX_ADDITIONAL_DIRECTORIES
+    || process.env.CTI_CODEX_ADDITIONAL_DIRS;
+  if (!raw) return undefined;
+  const dirs = raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return dirs.length > 0 ? dirs : undefined;
+}
+
+function getTurnSignal(abortController?: AbortController): AbortSignal | undefined {
+  const signals: AbortSignal[] = [];
+  const timeoutRaw = process.env.CTI_CODEX_TURN_TIMEOUT_MS;
+  const timeoutMs = timeoutRaw ? Number(timeoutRaw) : NaN;
+
+  if (abortController?.signal) {
+    signals.push(abortController.signal);
+  }
+  if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+    signals.push(AbortSignal.timeout(timeoutMs));
+  }
+  if (signals.length === 0) return undefined;
+  if (signals.length === 1) return signals[0];
+  if (typeof AbortSignal.any === 'function') {
+    return AbortSignal.any(signals);
+  }
+
+  const merged = new AbortController();
+  const abort = () => merged.abort();
+  for (const signal of signals) {
+    if (signal.aborted) {
+      merged.abort();
+      break;
+    }
+    signal.addEventListener('abort', abort, { once: true });
+  }
+  return merged.signal;
 }
 
 function shouldRetryFreshThread(message: string): boolean {
@@ -127,11 +193,18 @@ export class CodexProvider implements LLMProvider {
 
             const approvalPolicy = toApprovalPolicy(params.permissionMode);
             const passModel = shouldPassModelToCodex();
+            const sandboxMode = getSandboxMode(params.permissionMode);
+            const networkAccessEnabled = parseBooleanEnv('CTI_CODEX_NETWORK_ENABLED');
+            const additionalDirectories = getAdditionalDirectories();
+            const turnSignal = getTurnSignal(params.abortController);
 
             const threadOptions: Record<string, unknown> = {
               ...(passModel && params.model ? { model: params.model } : {}),
               ...(params.workingDirectory ? { workingDirectory: params.workingDirectory } : {}),
+              sandboxMode,
               ...(shouldSkipGitRepoCheck() ? { skipGitRepoCheck: true } : {}),
+              ...(networkAccessEnabled !== undefined ? { networkAccessEnabled } : {}),
+              ...(additionalDirectories ? { additionalDirectories } : {}),
               approvalPolicy,
             };
 
@@ -175,7 +248,10 @@ export class CodexProvider implements LLMProvider {
 
               let sawAnyEvent = false;
               try {
-                const { events } = await thread.runStreamed(input);
+                const { events } = await thread.runStreamed(
+                  input,
+                  turnSignal ? { signal: turnSignal } : undefined,
+                );
 
                 for await (const event of events) {
                   sawAnyEvent = true;


### PR DESCRIPTION
## Summary

This PR updates the skill-side Codex integration so that `/stop` can interrupt blocked Codex turns by passing the abort signal into the Codex SDK `runStreamed()` call.

It also documents the runtime settings needed for SSH/git workflows and for recovering from stuck sessions in Feishu/WeChat bridge usage.

## Changes

- pass abort signal into Codex SDK streamed turns
- add tests for turn cancellation and env-driven Codex runtime options
- document SSH/git-related Codex config in `config.env.example`
- add troubleshooting notes for stuck sessions and SSH/git access

## Validation

- `npm test`

## Out of scope

This PR only covers the `Claude-to-IM-skill` repository.

The following issues belong to the core `Claude-to-IM` repository and are not fixed here:

- same-session follow-up messages being silently queued
- Feishu CardKit fallback/degradation behavior when CardKit APIs are unavailable

## 摘要

这个 PR 修改了 skill 侧的 Codex 集成，使 `/stop` 能通过把 abort signal 传入 Codex SDK 的 `runStreamed()` 来中断卡住的 Codex turn。

同时补充了 Feishu/WeChat bridge 场景下 SSH/git 工作流和 stuck session 恢复所需的运行时配置说明。

## 变更内容

- 将 abort signal 传入 Codex SDK 的 streamed turn
- 增加 turn cancellation 和环境变量驱动运行参数的测试
- 在 `config.env.example` 中补充 SSH/git 相关 Codex 配置说明
- 在 `references/troubleshooting.md` 中补充 stuck session 与 SSH/git 的排障说明

## 验证

- `npm test`

## 不在本 PR 范围内

这个 PR 只覆盖 `Claude-to-IM-skill` 仓库。

以下问题属于核心仓库 `Claude-to-IM`，本 PR 不处理：

- 同一 session 后续消息静默排队
- Feishu CardKit API 不可用时的降级/回退逻辑
