### PR TITLE
fix: pass settingSources to SDK query() so filesystem skills are loaded

### DIFF
--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -467,6 +467,7 @@ export class SDKLLMProvider implements LLMProvider {
               resume: params.sdkSessionId || undefined,
               abortController: params.abortController,
               permissionMode: (params.permissionMode as 'default' | 'acceptEdits' | 'plan') || undefined,
+              settingSources: ['user', 'project', 'local'],
               includePartialMessages: true,
               env: cleanEnv,
               stderr: (data: string) => {


### PR DESCRIPTION
## Summary

- Added `settingSources: ['user', 'project', 'local']` to the `queryOptions` passed to the SDK `query()` call in `llm-provider.ts`
- Without this, the CLI subprocess only loads cloud plugins (`enabledPlugins` from `settings.json`), ignoring filesystem skills in `~/.claude/skills/` and `<project>/.claude/skills/`
- This caused bridge users to see only 4 skills (cloud plugins) instead of 50+ (filesystem skills + plugins)

## Root Cause

The SDK's `query()` function spawns a CLI subprocess. When `settingSources` is not explicitly provided, the CLI defaults to loading only cloud-based plugins rather than scanning the filesystem skill directories (`user`, `project`, `local` sources).

## Test Plan

- [x] Verified that before this change, Feishu bridge sessions only showed 4 cloud plugin skills
- [x] After adding `settingSources`, bridge sessions now load all filesystem skills
- [x] Tested by clearing stale sessions, restarting daemon, and confirming skill count via Feishu

🤖 Generated with [Claude Code](https://claude.com/claude-code)