### PR TITLE
fix: Windows portability fixes for weixin-login and supervisor

### DIFF
--- a/scripts/supervisor-windows.ps1
+++ b/scripts/supervisor-windows.ps1
@@ -33,8 +33,8 @@ $SkillDir   = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
 $RuntimeDir = Join-Path $CtiHome 'runtime'
 $PidFile    = Join-Path $RuntimeDir 'bridge.pid'
 $StatusFile = Join-Path $RuntimeDir 'status.json'
-$LogFile    = Join-Path $CtiHome 'logs' 'bridge.log'
-$DaemonMjs  = Join-Path $SkillDir 'dist' 'daemon.mjs'
+$LogFile    = Join-Path (Join-Path $CtiHome 'logs') 'bridge.log'
+$DaemonMjs  = Join-Path (Join-Path $SkillDir 'dist') 'daemon.mjs'
 
 $ServiceName = 'ClaudeToIMBridge'
 
@@ -72,9 +72,9 @@ function Read-Pid {
 }
 
 function Test-PidAlive {
-    param([string]$Pid)
-    if (-not $Pid) { return $false }
-    try { $null = Get-Process -Id ([int]$Pid) -ErrorAction Stop; return $true }
+    param([string]$ProcId)
+    if (-not $ProcId) { return $false }
+    try { $null = Get-Process -Id ([int]$ProcId) -ErrorAction Stop; return $true }
     catch { return $false }
 }
 
@@ -221,12 +221,13 @@ function Start-Fallback {
     # Remove CLAUDECODE
     [System.Environment]::SetEnvironmentVariable('CLAUDECODE', $null)
 
+    $ErrLogFile = "$LogFile.err"
     $proc = Start-Process -FilePath $nodePath `
         -ArgumentList $DaemonMjs `
         -WorkingDirectory $SkillDir `
         -WindowStyle Hidden `
         -RedirectStandardOutput $LogFile `
-        -RedirectStandardError $LogFile `
+        -RedirectStandardError $ErrLogFile `
         -PassThru
 
     # Write initial PID (main.ts will overwrite with real PID)
@@ -267,7 +268,7 @@ switch ($Command) {
             }
         } else {
             Write-Host "Starting bridge (background process)..."
-            $pid = Start-Fallback
+            $startedPid = Start-Fallback
             Start-Sleep -Seconds 3
 
             $newPid = Read-Pid
@@ -294,10 +295,10 @@ switch ($Command) {
             Write-Host "Bridge stopped"
             if (Test-Path $PidFile) { Remove-Item $PidFile -Force }
         } else {
-            $pid = Read-Pid
-            if (-not $pid) { Write-Host "No bridge running"; exit 0 }
-            if (Test-PidAlive $pid) {
-                Stop-Process -Id ([int]$pid) -Force
+            $runPid = Read-Pid
+            if (-not $runPid) { Write-Host "No bridge running"; exit 0 }
+            if (Test-PidAlive $runPid) {
+                Stop-Process -Id ([int]$runPid) -Force
                 Write-Host "Bridge stopped"
             } else {
                 Write-Host "Bridge was not running (stale PID file)"
@@ -307,7 +308,7 @@ switch ($Command) {
     }
 
     'status' {
-        $pid = Read-Pid
+        $runPid = Read-Pid
 
         # Check Windows Service
         $svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
@@ -315,8 +316,8 @@ switch ($Command) {
             Write-Host "Windows Service '$ServiceName': $($svc.Status)"
         }
 
-        if ($pid -and (Test-PidAlive $pid)) {
-            Write-Host "Bridge process is running (PID: $pid)"
+        if ($runPid -and (Test-PidAlive $runPid)) {
+            Write-Host "Bridge process is running (PID: $runPid)"
             if (Test-StatusRunning) {
                 Write-Host "Bridge status: running"
             } else {

--- a/scripts/supervisor-windows.ps1
+++ b/scripts/supervisor-windows.ps1
@@ -210,8 +210,33 @@ function Install-NSSMService {
 
 # ── Fallback: Start-Process (no service manager) ──
 
+function Load-ConfigEnv {
+    # Load ~/.claude-to-im/config.env into process env so the daemon inherits
+    # CTI_* vars (the POSIX daemon.sh does this via `source`; on Windows the
+    # shell branch exits before that line, so we replicate it here).
+    $configFile = Join-Path $CtiHome 'config.env'
+    if (-not (Test-Path $configFile)) { return }
+    foreach ($line in Get-Content $configFile) {
+        $trimmed = $line.Trim()
+        if (-not $trimmed -or $trimmed.StartsWith('#')) { continue }
+        $eq = $trimmed.IndexOf('=')
+        if ($eq -lt 1) { continue }
+        $key = $trimmed.Substring(0, $eq).Trim()
+        $value = $trimmed.Substring($eq + 1).Trim()
+        # Strip matching surrounding quotes
+        if (($value.StartsWith('"') -and $value.EndsWith('"')) -or
+            ($value.StartsWith("'") -and $value.EndsWith("'"))) {
+            $value = $value.Substring(1, $value.Length - 2)
+        }
+        [System.Environment]::SetEnvironmentVariable($key, $value)
+    }
+}
+
 function Start-Fallback {
     $nodePath = Get-NodePath
+
+    # Load config.env first (Windows-specific — daemon.sh skips its source step)
+    Load-ConfigEnv
 
     # Clean env
     $envClone = [System.Collections.Hashtable]::new()

--- a/src/weixin-login.ts
+++ b/src/weixin-login.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 import QRCode from 'qrcode';
 import { CTI_HOME, loadConfig } from './config.js';
@@ -263,7 +264,7 @@ export async function runWeixinLogin(): Promise<{ accountId: string; htmlPath: s
 
 const isMainModule = (() => {
   const entry = process.argv[1];
-  return !!entry && path.resolve(entry) === path.resolve(new URL(import.meta.url).pathname);
+  return !!entry && path.resolve(entry) === path.resolve(fileURLToPath(import.meta.url));
 })();
 
 if (isMainModule) {


### PR DESCRIPTION
## Summary

Four Windows-specific bugs that all block `/claude-to-im setup` + `/claude-to-im start` on Git Bash + PowerShell 5.1. Each hits a different layer of the skill but they stack — you fix one and the next one surfaces.

### 1. `src/weixin-login.ts` — QR login helper exits silently

`new URL(import.meta.url).pathname` returns a URL-encoded path with a leading slash on Windows (e.g. `/C:/Users/...`), which never equals `path.resolve(process.argv[1])` even after normalization. The main-module guard falls through and the script exits with code 0 without starting the QR flow — no error, no output.

Fix: use `fileURLToPath(import.meta.url)` so the comparison works on all platforms.

### 2. `scripts/supervisor-windows.ps1` — three-arg `Join-Path`

```
A positional parameter cannot be found that accepts argument 'bridge.log'
```

Windows PowerShell 5.1's `Join-Path` only takes `-Path` and `-ChildPath`. The three-arg forms for `$LogFile` and `$DaemonMjs` fail at script load, so `daemon.sh start` dies before doing anything. Fix: nest the calls.

### 3. `scripts/supervisor-windows.ps1` — same file for stdout + stderr

```
'RedirectStandardOutput' and 'RedirectStandardError' are same. Give different inputs
```

`Start-Process` refuses to redirect both streams to the same file. Fix: send stderr to `bridge.log.err`.

### 4. `scripts/supervisor-windows.ps1` — `$PID` collision

```
Cannot overwrite variable PID because it is read-only or constant
```

`$PID` is a PowerShell automatic read-only variable. The script assigns to `$pid` and binds a `[string]$Pid` parameter, both of which fail. Fix: rename the locals (`$startedPid`, `$runPid`) and the parameter (`$ProcId`).

### 5. `scripts/supervisor-windows.ps1` — config.env never reaches the daemon

On POSIX, `daemon.sh` sources `~/.claude-to-im/config.env` before calling `supervisor_start`, so the daemon inherits every `CTI_*` env var. On Windows the MINGW branch `exec`s into PowerShell and returns immediately — the `source` step below it never runs.

Most keys still work because `loadConfig()` re-reads the file directly. But a few (notably `CTI_CLAUDE_CODE_EXECUTABLE`, which is read via `process.env.CTI_CLAUDE_CODE_EXECUTABLE` in `llm-provider.ts`) rely on the variable being in the actual process env. On Windows the SDK always fell back to whatever `claude` it found first in PATH — often the npm-wrapper shim that fails the native-binary check with:

```
Error: Claude Code native binary not found at C:\Users\wang\AppData\Roaming\npm\claude
```

Fix: add a `Load-ConfigEnv` helper to the supervisor that parses `config.env` (same rules as `config.ts`: skip blanks and comments, strip matching surrounding quotes) and injects every key into the process env before `Start-Process`.

## Test plan

- [x] `node --import tsx src/weixin-login.ts` now writes `~/.claude-to-im/runtime/weixin-login.html`, opens the browser, polls for QR scan, and saves the linked account on confirmation.
- [x] `bash scripts/daemon.sh start` successfully launches the daemon on Windows 11 (Git Bash, Node 22.17, PowerShell 5.1). `status` and `logs` work. Bridge received the `weixin` adapter start event and is polling.
- [x] With `CTI_CLAUDE_CODE_EXECUTABLE` pointed at the real Claude Code native binary (`...\npm\node_modules\@anthropic-ai\claude-code\bin\claude.exe`), the preflight log now shows the configured path instead of the PATH wrapper.
- [x] No changes to macOS / Linux paths (POSIX-specific code is untouched; `fileURLToPath` behaves identically to the old pathname on POSIX; `Load-ConfigEnv` is Windows-only).

## Not in this PR

One other install hiccup for Windows that I worked around locally but did not patch here: `package.json`'s `"claude-to-im": "file:../Claude-to-IM"` collides with the case-insensitive filesystem when the skill is cloned into `~/.claude/skills/claude-to-im` (`../Claude-to-IM` resolves back to the skill itself). This looks like an intentional monorepo-style dev layout, so I didn't touch it — happy to send a separate PR if you'd like a Windows-safe install path documented in the README.