### PR TITLE
fix: forward session systemPrompt to SDK query() options

### DIFF
--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -469,6 +469,9 @@ export class SDKLLMProvider implements LLMProvider {
               permissionMode: (params.permissionMode as 'default' | 'acceptEdits' | 'plan') || undefined,
               includePartialMessages: true,
               env: cleanEnv,
+              ...(params.systemPrompt ? {
+                systemPrompt: { type: 'preset', preset: 'claude_code', append: params.systemPrompt },
+              } : {}),
               stderr: (data: string) => {
                 stderrBuf += data;
                 if (stderrBuf.length > MAX_STDERR) {


### PR DESCRIPTION
 ## Problem

`streamChat()` receives `params.systemPrompt` (populated by `conversation-engine` from `session.system_prompt`), but `queryOptions` never includes it. The value is silently dropped and the LLM never sees it.

This is the second half of a two-part issue — even after the session's system_prompt is correctly populated, the prompt still wouldn't reach Claude without this fix.

## Fix

Pass the system prompt via the SDK's append mode:

  systemPrompt: { type: 'preset', preset: 'claude_code', append: '...' }

Using `append` (rather than a plain string) preserves Claude Code's built-in system prompt — tool instructions, CLAUDE.md content, permission rules — while layering the custom persona on top.