### PR TITLE
fix(llm-provider): load CLAUDE.md via settingSources

### DIFF
--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -463,6 +463,11 @@ export class SDKLLMProvider implements LLMProvider {
 
             const queryOptions: Record<string, unknown> = {
               cwd: params.workingDirectory,
+              // Required so the SDK loads <cwd>/CLAUDE.md (project memory) +
+              // ~/.claude/CLAUDE.md (user memory). Without 'project', the
+              // bridge-spawned Claude has no project context. Per agent SDK
+              // docs: "Must include 'project' to load CLAUDE.md files."
+              settingSources: ['user', 'project'],
               model,
               resume: params.sdkSessionId || undefined,
               abortController: params.abortController,


### PR DESCRIPTION
## Summary

The Agent SDK runs in **isolation mode** by default — when `settingSources` is omitted, no filesystem settings load. That means the bridge-spawned Claude ignores both `~/.claude/CLAUDE.md` (user memory) and the per-cwd `CLAUDE.md` (project memory), and answers the user as if launched from a fresh shell.

For groups whose behavior is defined entirely in a project `CLAUDE.md` (chat-id routing, persona, command shortcuts), this silently broke chat-mode — Claude responded as a generic assistant instead of the configured agent.

## Fix

Pass \`settingSources: ['user', 'project']\` to \`query()\` so both memories load.

Per \`@anthropic-ai/claude-agent-sdk\` type docs:

> \`settingSources\`: Must include \`'project'\` to load CLAUDE.md files. When omitted or empty, no filesystem settings are loaded (SDK isolation mode).

## Test plan

- [x] Reproduced: bridge-spawned Claude in a Feishu group answered with no project context, despite the workingDirectory being correct
- [x] Applied fix locally, rebuilt \`dist/daemon.mjs\`, cleared the per-chat session binding to force a fresh spawn
- [x] Verified next message correctly loaded \`CLAUDE.md\` and routed by \`chat_id\` per project rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)