### PR TITLE
fix: load user/project/local MCP servers by passing settingSources

### DIFF
--- a/src/llm-provider.ts
+++ b/src/llm-provider.ts
@@ -469,6 +469,16 @@ export class SDKLLMProvider implements LLMProvider {
               permissionMode: (params.permissionMode as 'default' | 'acceptEdits' | 'plan') || undefined,
               includePartialMessages: true,
               env: cleanEnv,
+              // Claude Agent SDK defaults settingSources to [], while the CLI
+              // (claude / claude -p / claude --output-format stream-json) defaults
+              // to ['user', 'project', 'local']. Without this, child processes
+              // spawned via the SDK silently skip loading ~/.claude.json and
+              // cwd/.mcp.json — every user-level and project-level MCP server
+              // (plaud-recorder, iflytek-recorder, flomo, any custom .mcp.json
+              // entry) disappears from the tool menu. The bridge user expects
+              // their bot to have the same tools their local Claude Code session
+              // has, so we explicitly opt in to all three sources.
+              settingSources: ['user', 'project', 'local'],
               stderr: (data: string) => {
                 stderrBuf += data;
                 if (stderrBuf.length > MAX_STDERR) {


### PR DESCRIPTION
## Summary

The Claude Agent SDK defaults `settingSources` to `[]`, while the CLI (`claude`, `claude -p`, `claude --output-format stream-json`) defaults to `['user', 'project', 'local']`. Child processes spawned by the bridge therefore silently skip loading `~/.claude.json` and `cwd/.mcp.json`, and every user-level / project-level MCP server (plaud-recorder, iflytek-recorder, flomo, any custom `.mcp.json` entry) disappears from the tool menu.

The IM user reasonably expects their bot to see the same MCP tools their local Claude Code session sees. This PR passes `settingSources: ['user', 'project', 'local']` explicitly so the SDK loads them.

## Reproduction (before patch)

On a host with:
- `~/.claude.json` containing a `flomo` HTTP MCP server
- `/path/to/project/.mcp.json` containing `plaud-recorder`, `iflytek-recorder`, `wechat-to-md`

Telegram conversation with the bot:

> **Me**: List MCP tools whose name starts with `mcp__plaud-recorder`.
> **Bot** (before patch): The tool menu does not contain any `mcp__plaud-recorder__*` tools.

Direct SDK reproducer:

```js
import { query } from '@anthropic-ai/claude-agent-sdk';
const q = query({
  prompt: 'NONE',
  options: {
    cwd: '/path/with/.mcp.json',
    canUseTool: async () => ({ behavior: 'deny' }),
    includePartialMessages: true,
    // settingSources: ['user', 'project', 'local'],  // toggle this line
  },
});
for await (const m of q) {
  if (m.type === 'system' && m.subtype === 'init') {
    console.log(m.mcp_servers);
    break;
  }
}
process.exit(0);
```

Output **without** `settingSources`:

```json
[
  { "name": "claude.ai Google Drive", "status": "connected" },
  { "name": "claude.ai Google Calendar", "status": "needs-auth" },
  { "name": "claude.ai Gmail", "status": "needs-auth" }
]
```

Output **with** `settingSources: ['user', 'project', 'local']`:

```json
[
  { "name": "flomo", "status": "connected" },
  { "name": "iflytek-recorder", "status": "connected" },
  { "name": "plaud-recorder", "status": "connected" },
  { "name": "wechat-to-md", "status": "connected" },
  { "name": "claude.ai Google Drive", "status": "connected" }
]
```

After the patch, the Telegram bot lists and invokes plaud / iflytek / flomo / wechat-to-md exactly like the user's local Claude Code session.

## Risk

Minimal — one-line behavioral change (plus comment) that opts the bridge into the same settings sources a user's local CLI session would load. Aligns with the principle of least surprise for IM bridge users.

## Test plan

- [x] Telegram smoke test before/after on a real bot with a populated `.mcp.json`
- [x] SDK reproducer before/after (output shown above)
