### PR TITLE
feat: multi-profile bridges — run Codex + Claude Code side by side from one install

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -184,6 +184,33 @@ For more complex issues (messages not received, permission timeouts, high memory
 
 **Feishu upgrade note:** If the user upgraded from an older version of this skill and Feishu is returning permission errors (e.g. streaming cards not working, typing indicators failing, permission buttons unresponsive), the root cause is almost certainly missing permissions or callbacks in the Feishu backend. Refer the user to the "Upgrading from a previous version" section in `SKILL_DIR/references/setup-guides.md` — they need to add new scopes (`cardkit:card:write`, `cardkit:card:read`, `im:message:update`, `im:message.reactions:read`, `im:message.reactions:write_only`), add the `card.action.trigger` callback, and re-publish the app. The upgrade requires two publish cycles because adding the callback needs an active WebSocket connection (bridge must be running).
 
+## Multi-profile (run Codex and Claude Code bridges side by side)
+
+When the user runs both a Codex bridge and a Claude Code bridge on one machine, manage them through the unified wrapper instead of juggling `CTI_HOME` by hand:
+
+```bash
+scripts/bridges.sh list           # show configured profiles
+scripts/bridges.sh status all     # status of every profile
+scripts/bridges.sh doctor all     # per-profile doctor + launchd disabled check + config.env perms
+scripts/bridges.sh logs codex     # single-profile commands take the profile id
+scripts/bridges.sh start claude
+```
+
+Profiles live in `~/.claude-to-im/bridges.json` (override with `CTI_BRIDGES_CONFIG`); each entry sets `id`, `runtime` (`codex`/`claude`), `home`, `launchdLabel`, `channels`:
+
+```json
+{
+  "bridges": [
+    { "id": "codex",  "runtime": "codex",  "home": "/Users/me/.claude-to-im",        "launchdLabel": "com.claude-to-im.bridge",        "channels": ["feishu"] },
+    { "id": "claude", "runtime": "claude", "home": "/Users/me/.claude-to-im-claude", "launchdLabel": "com.claude-to-im.bridge.claude", "channels": ["feishu"] }
+  ]
+}
+```
+
+The parser is `src/profiles.ts` — duplicate ids/labels/homes are hard errors (two daemons sharing one home corrupt state). Secrets stay in each profile's `config.env` (chmod 600); `bridges.json` must never contain them.
+
+Doctor triage order for "bridge not replying": ① is the launchd label disabled? (`launchctl print-disabled gui/$(id -u)`) ② is the daemon process alive? ③ does the log show the websocket client ready? A disabled label is the most common silent failure — `doctor all` checks it first.
+
 ## Notes
 
 - Always mask secrets in output (show only last 4 characters) — users often share terminal output in bug reports, so exposed tokens would be a security incident.

--- a/scripts/bridges.sh
+++ b/scripts/bridges.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Unified multi-profile supervisor wrapper (phase 1 MVP).
+# Reads bridges.json, sets CTI_HOME / CTI_LAUNCHD_LABEL per profile, and
+# delegates to the existing daemon.sh / doctor.sh. No secrets are read or printed.
+#
+# Usage:
+#   bridges.sh start|stop|status|logs|doctor all
+#   bridges.sh start|stop|status|logs|doctor <profile-id>
+#   bridges.sh list
+
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG="${CTI_BRIDGES_CONFIG:-$HOME/.claude-to-im/bridges.json}"
+
+usage() {
+  sed -n '5,11p' "$0" | sed 's/^# \{0,1\}//'
+  exit 1
+}
+
+[ $# -ge 1 ] || usage
+CMD="$1"
+TARGET="${2:-all}"
+
+case "$CMD" in
+  start|stop|status|logs|doctor|list) ;;
+  *) usage ;;
+esac
+
+if [ ! -f "$CONFIG" ]; then
+  echo "bridges config not found: $CONFIG" >&2
+  echo "Create it first (see SKILL.md 'Multi-profile') or set CTI_BRIDGES_CONFIG." >&2
+  exit 1
+fi
+
+# Parse + validate via node; emit tab-separated "id runtime home label".
+# Validation rules mirror src/profiles.ts (single source of truth is the TS
+# module; this inline check covers the same hard failures for shell callers).
+profiles_tsv() {
+  node -e '
+    const fs = require("fs"), path = require("path");
+    const file = process.argv[1];
+    let cfg;
+    try { cfg = JSON.parse(fs.readFileSync(file, "utf8")); }
+    catch (e) { console.error("invalid JSON in " + file + ": " + e.message); process.exit(1); }
+    if (!cfg || !Array.isArray(cfg.bridges) || cfg.bridges.length === 0) {
+      console.error("bridges config must have a non-empty \"bridges\" array"); process.exit(1);
+    }
+    const ids = new Set(), labels = new Set(), homes = new Set();
+    for (const b of cfg.bridges) {
+      if (!/^[a-z0-9][a-z0-9-]*$/.test(b.id || "")) { console.error("bad profile id: " + JSON.stringify(b.id)); process.exit(1); }
+      if (!["claude","codex"].includes(b.runtime)) { console.error(b.id + ": bad runtime " + JSON.stringify(b.runtime)); process.exit(1); }
+      if (typeof b.home !== "string" || !path.isAbsolute(b.home)) { console.error(b.id + ": home must be absolute"); process.exit(1); }
+      if (!/^[A-Za-z0-9.-]+$/.test(b.launchdLabel || "")) { console.error(b.id + ": bad launchdLabel"); process.exit(1); }
+      if (ids.has(b.id) || labels.has(b.launchdLabel) || homes.has(path.normalize(b.home))) {
+        console.error("duplicate id/label/home around profile " + b.id); process.exit(1);
+      }
+      ids.add(b.id); labels.add(b.launchdLabel); homes.add(path.normalize(b.home));
+      console.log([b.id, b.runtime, b.home, b.launchdLabel].join("\t"));
+    }
+  ' "$CONFIG"
+}
+
+PROFILES="$(profiles_tsv)"
+
+if [ "$CMD" = "list" ]; then
+  printf 'ID\tRUNTIME\tHOME\tLAUNCHD_LABEL\n%s\n' "$PROFILES" | column -t -s $'\t'
+  exit 0
+fi
+
+run_one() {
+  local id="$1" runtime="$2" home="$3" label="$4"
+  echo "── profile: $id (runtime=$runtime) ──"
+  case "$CMD" in
+    doctor)
+      # A disabled launchd label is the most common silent failure — check it before doctor.sh.
+      local uid; uid="$(id -u)"
+      if launchctl print-disabled "gui/$uid" 2>/dev/null | grep -q "\"$label\" => disabled"; then
+        echo "[FAIL] launchd label $label is DISABLED — fix: launchctl enable gui/$uid/$label"
+      else
+        echo "[OK]   launchd label $label not disabled"
+      fi
+      if [ ! -f "$home/config.env" ]; then
+        echo "[FAIL] $home/config.env missing"
+      else
+        local perms; perms="$(stat -f '%Lp' "$home/config.env" 2>/dev/null || stat -c '%a' "$home/config.env" 2>/dev/null)"
+        if [ "$perms" = "600" ]; then
+          echo "[OK]   config.env exists with 600 permissions"
+        else
+          echo "[WARN] config.env permissions are $perms (expected 600)"
+        fi
+      fi
+      CTI_HOME="$home" CTI_LAUNCHD_LABEL="$label" bash "$SKILL_DIR/scripts/doctor.sh" || true
+      ;;
+    logs)
+      CTI_HOME="$home" CTI_LAUNCHD_LABEL="$label" bash "$SKILL_DIR/scripts/daemon.sh" logs
+      ;;
+    *)
+      CTI_HOME="$home" CTI_LAUNCHD_LABEL="$label" bash "$SKILL_DIR/scripts/daemon.sh" "$CMD"
+      ;;
+  esac
+  echo
+}
+
+FOUND=0
+while IFS=$'\t' read -r id runtime home label; do
+  [ -n "$id" ] || continue
+  if [ "$TARGET" = "all" ] || [ "$TARGET" = "$id" ]; then
+    FOUND=1
+    run_one "$id" "$runtime" "$home" "$label"
+  fi
+done <<< "$PROFILES"
+
+if [ "$FOUND" = "0" ]; then
+  echo "unknown profile: $TARGET" >&2
+  echo "known profiles:" >&2
+  printf '%s\n' "$PROFILES" | cut -f1 | sed 's/^/  - /' >&2
+  exit 1
+fi

--- a/scripts/supervisor-macos.sh
+++ b/scripts/supervisor-macos.sh
@@ -2,7 +2,7 @@
 # macOS supervisor — launchd-based process management.
 # Sourced by daemon.sh; expects CTI_HOME, SKILL_DIR, PID_FILE, STATUS_FILE, LOG_FILE.
 
-LAUNCHD_LABEL="com.claude-to-im.bridge"
+LAUNCHD_LABEL="${CTI_LAUNCHD_LABEL:-com.claude-to-im.bridge}"
 PLIST_DIR="$HOME/Library/LaunchAgents"
 PLIST_FILE="$PLIST_DIR/$LAUNCHD_LABEL.plist"
 

--- a/src/__tests__/profiles.test.ts
+++ b/src/__tests__/profiles.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseBridgesConfig, getProfile } from '../profiles.js';
+
+const VALID = JSON.stringify({
+  bridges: [
+    {
+      id: 'codex',
+      runtime: 'codex',
+      home: '/Users/demo/.claude-to-im',
+      launchdLabel: 'com.claude-to-im.bridge',
+      channels: ['feishu'],
+    },
+    {
+      id: 'claude',
+      runtime: 'claude',
+      home: '/Users/demo/.claude-to-im-claude',
+      launchdLabel: 'com.claude-to-im.bridge.claude',
+      channels: ['feishu'],
+    },
+  ],
+});
+
+describe('parseBridgesConfig', () => {
+  it('parses a valid two-profile config', () => {
+    const cfg = parseBridgesConfig(VALID, 'test');
+    assert.equal(cfg.bridges.length, 2);
+    assert.equal(cfg.bridges[0].id, 'codex');
+    assert.equal(cfg.bridges[1].runtime, 'claude');
+  });
+
+  it('rejects invalid JSON', () => {
+    assert.throws(() => parseBridgesConfig('{nope', 'test'), /not valid JSON/);
+  });
+
+  it('rejects missing bridges array', () => {
+    assert.throws(() => parseBridgesConfig('{}', 'test'), /"bridges" array/);
+  });
+
+  it('rejects empty bridges array', () => {
+    assert.throws(() => parseBridgesConfig('{"bridges":[]}', 'test'), /empty/);
+  });
+
+  it('rejects duplicate ids', () => {
+    const dup = JSON.parse(VALID);
+    dup.bridges[1].id = 'codex';
+    dup.bridges[1].home = '/Users/demo/other';
+    dup.bridges[1].launchdLabel = 'com.other';
+    assert.throws(() => parseBridgesConfig(JSON.stringify(dup), 'test'), /duplicate profile id/);
+  });
+
+  it('rejects invalid runtime', () => {
+    const bad = JSON.parse(VALID);
+    bad.bridges[0].runtime = 'gemini';
+    assert.throws(() => parseBridgesConfig(JSON.stringify(bad), 'test'), /runtime/);
+  });
+
+  it('rejects relative home', () => {
+    const bad = JSON.parse(VALID);
+    bad.bridges[0].home = 'relative/path';
+    assert.throws(() => parseBridgesConfig(JSON.stringify(bad), 'test'), /absolute path/);
+  });
+
+  it('rejects shared home between profiles', () => {
+    const bad = JSON.parse(VALID);
+    bad.bridges[1].home = bad.bridges[0].home;
+    assert.throws(() => parseBridgesConfig(JSON.stringify(bad), 'test'), /duplicate profile home/);
+  });
+
+  it('rejects bad launchd label characters', () => {
+    const bad = JSON.parse(VALID);
+    bad.bridges[0].launchdLabel = 'com bridge with spaces';
+    assert.throws(() => parseBridgesConfig(JSON.stringify(bad), 'test'), /launchdLabel/);
+  });
+
+  it('rejects duplicate launchd labels', () => {
+    const bad = JSON.parse(VALID);
+    bad.bridges[1].launchdLabel = bad.bridges[0].launchdLabel;
+    assert.throws(() => parseBridgesConfig(JSON.stringify(bad), 'test'), /duplicate launchdLabel/);
+  });
+
+  it('rejects empty channels', () => {
+    const bad = JSON.parse(VALID);
+    bad.bridges[0].channels = [];
+    assert.throws(() => parseBridgesConfig(JSON.stringify(bad), 'test'), /channels/);
+  });
+});
+
+describe('getProfile', () => {
+  it('finds a profile by id and errors on unknown id', () => {
+    const cfg = parseBridgesConfig(VALID, 'test');
+    assert.equal(getProfile(cfg, 'claude').runtime, 'claude');
+    assert.throws(() => getProfile(cfg, 'nope'), /unknown profile "nope" \(known: codex, claude\)/);
+  });
+});

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Multi-profile bridge configuration (phase 1: unified project + per-profile daemons).
+// bridges.json lives outside the skill repo so dependency updates never touch it.
+// Secrets stay in each profile's config.env (chmod 600); this parser never reads them.
+
+export interface BridgeProfile {
+  id: string;
+  runtime: "claude" | "codex";
+  home: string;
+  launchdLabel: string;
+  channels: string[];
+}
+
+export interface BridgesConfig {
+  bridges: BridgeProfile[];
+}
+
+export const BRIDGES_CONFIG_PATH =
+  process.env.CTI_BRIDGES_CONFIG ||
+  path.join(os.homedir(), ".claude-to-im", "bridges.json");
+
+const VALID_RUNTIMES = new Set(["claude", "codex"]);
+const ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+const LABEL_RE = /^[A-Za-z0-9.-]+$/;
+
+export function parseBridgesConfig(raw: string, source = BRIDGES_CONFIG_PATH): BridgesConfig {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`bridges config is not valid JSON (${source}): ${(e as Error).message}`);
+  }
+  if (typeof data !== "object" || data === null || !Array.isArray((data as BridgesConfig).bridges)) {
+    throw new Error(`bridges config must be an object with a "bridges" array (${source})`);
+  }
+  const bridges = (data as BridgesConfig).bridges;
+  if (bridges.length === 0) {
+    throw new Error(`bridges config has an empty "bridges" array (${source})`);
+  }
+
+  const seenIds = new Set<string>();
+  const seenLabels = new Set<string>();
+  const seenHomes = new Set<string>();
+
+  for (const [i, b] of bridges.entries()) {
+    const where = `bridges[${i}]`;
+    if (typeof b.id !== "string" || !ID_RE.test(b.id)) {
+      throw new Error(`${where}.id must match ${ID_RE} (got ${JSON.stringify(b.id)})`);
+    }
+    if (seenIds.has(b.id)) throw new Error(`duplicate profile id "${b.id}"`);
+    seenIds.add(b.id);
+
+    if (typeof b.runtime !== "string" || !VALID_RUNTIMES.has(b.runtime)) {
+      throw new Error(`${where}.runtime must be one of ${[...VALID_RUNTIMES].join("/")} (got ${JSON.stringify(b.runtime)})`);
+    }
+
+    if (typeof b.home !== "string" || !path.isAbsolute(b.home)) {
+      throw new Error(`${where}.home must be an absolute path (got ${JSON.stringify(b.home)})`);
+    }
+    const normHome = path.normalize(b.home);
+    if (seenHomes.has(normHome)) throw new Error(`duplicate profile home "${normHome}" — two daemons sharing one home will corrupt state`);
+    seenHomes.add(normHome);
+
+    if (typeof b.launchdLabel !== "string" || !LABEL_RE.test(b.launchdLabel)) {
+      throw new Error(`${where}.launchdLabel must match ${LABEL_RE} (got ${JSON.stringify(b.launchdLabel)})`);
+    }
+    if (seenLabels.has(b.launchdLabel)) throw new Error(`duplicate launchdLabel "${b.launchdLabel}"`);
+    seenLabels.add(b.launchdLabel);
+
+    if (!Array.isArray(b.channels) || b.channels.length === 0 || !b.channels.every((c) => typeof c === "string")) {
+      throw new Error(`${where}.channels must be a non-empty string array`);
+    }
+  }
+  return { bridges };
+}
+
+export function loadBridgesConfig(configPath = BRIDGES_CONFIG_PATH): BridgesConfig {
+  if (!fs.existsSync(configPath)) {
+    throw new Error(
+      `bridges config not found: ${configPath}\n` +
+        `Create it with a "bridges" array (see SKILL.md "Multi-profile"), or set CTI_BRIDGES_CONFIG.`,
+    );
+  }
+  return parseBridgesConfig(fs.readFileSync(configPath, "utf8"), configPath);
+}
+
+export function getProfile(config: BridgesConfig, id: string): BridgeProfile {
+  const p = config.bridges.find((b) => b.id === id);
+  if (!p) {
+    const known = config.bridges.map((b) => b.id).join(", ");
+    throw new Error(`unknown profile "${id}" (known: ${known})`);
+  }
+  return p;
+}


### PR DESCRIPTION
## Why

Many users run **both** a Codex bridge and a Claude Code bridge on the same machine. Today that means two installs, two homes, two launchd labels, and hand-set `CTI_HOME` for every command — and when one stops replying, diagnosing which of the two broke is painful.

很多用户在同一台机器上同时跑 Codex 和 Claude Code 两座桥。现在需要两套目录、两个 launchd label、每条命令手动设 `CTI_HOME`,哪座桥不回话了排查起来很费劲。

## What

- **`src/profiles.ts`** — parser for `~/.claude-to-im/bridges.json` (`id` / `runtime` / `home` / `launchdLabel` / `channels`). Duplicate ids, labels, or homes are hard errors (two daemons sharing one home corrupt state). It never reads or prints secrets — those stay in each profile's `config.env` (chmod 600).
- **`scripts/bridges.sh`** — unified wrapper: `bridges.sh start|stop|status|logs|doctor all` or `<profile-id>`. Internally sets `CTI_HOME` / `CTI_LAUNCHD_LABEL` and delegates to the existing `daemon.sh` / `doctor.sh` — no changes to their behavior.
- **`scripts/supervisor-macos.sh`** — one line: the launchd label becomes `${CTI_LAUNCHD_LABEL:-com.claude-to-im.bridge}`. Default unchanged, so single-profile users are unaffected.
- **`SKILL.md`** — multi-profile section with a config example and a doctor triage order (a *disabled* launchd label is the most common silent failure, so `doctor all` checks it first, plus `config.env` permission checks).
- **12 unit tests** for the parser (missing fields, duplicate id/label/home, bad runtime, relative paths…).

## Validation

- `npm test`: 146/147 pass — the 1 failure (`weixin-adapter.test.ts`, `ERR_MODULE_NOT_FOUND: claude-to-im`) pre-exists on a clean checkout of `main` and is unrelated.
- Verified on a real machine running both bridges side by side: `bridges.sh list / status all / doctor all` correctly report two live daemons under their own labels and homes.
- Zero behavior change for existing single-profile installs: without `bridges.json`, nothing differs.

## Out of scope (possible follow-ups)

- Migrating the legacy two-home layout into a `profiles/` tree (we kept a dry-run plan out of this PR to keep it minimal).
- Single-process multi-runtime (the bridge context is a global singleton today; per-profile daemons sidestep that).